### PR TITLE
Fix build when no package.json

### DIFF
--- a/pkg/build/examples/typescript/nopackagejson/main.ts
+++ b/pkg/build/examples/typescript/nopackagejson/main.ts
@@ -1,0 +1,9 @@
+// Linked to https://app.airplane.dev/t/typescript_no_package_json [do not edit this line]
+
+type Params = {
+  id: string
+}
+
+export default async function(params: Params) {
+  console.log(`airplane_output "${params.id}"`);
+}

--- a/pkg/build/node.go
+++ b/pkg/build/node.go
@@ -145,21 +145,27 @@ func node(root string, options KindOptions) (string, error) {
 			cd /airplane/.airplane && \
 			{{.InlineShimPackageJSON}} > package.json && \
 			npm install
+
+		{{if .HasPackageJSON}}
 		COPY package*.json yarn.* /airplane/
-		{{if not .HasPackageJSON}}
+		{{else}}
 		RUN echo '{}' > /airplane/package.json
 		{{end}}
+
 		{{if .UsesWorkspaces}}
 		COPY . /airplane
 		{{end}}
+
 		{{if .IsYarn}}
 		RUN yarn --non-interactive
 		{{else}}
 		RUN npm install
 		{{end}}
+
 		{{if not .UsesWorkspaces}}
 		COPY . /airplane
 		{{end}}
+		
 		RUN {{.InlineShim}} > /airplane/.airplane/shim.js && \
 			esbuild /airplane/.airplane/shim.js \
 				--bundle \

--- a/pkg/build/node_test.go
+++ b/pkg/build/node_test.go
@@ -125,6 +125,14 @@ func TestNodeBuilder(t *testing.T) {
 				"entrypoint": "pkg2/src/index.ts",
 			},
 		},
+		{
+			Root: "typescript/nopackagejson",
+			Kind: TaskKindNode,
+			Options: KindOptions{
+				"shim":       "true",
+				"entrypoint": "main.ts",
+			},
+		},
 	}
 
 	RunTests(t, ctx, tests)


### PR DESCRIPTION
Errors if no package.json because there are no package*.json or yarn.* files.

Added test to confirm fix