### PR TITLE
Fix parameter schema in Definition_0_3

### DIFF
--- a/pkg/deploy/taskdir/definitions/def_0_3.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3.go
@@ -424,8 +424,8 @@ type ParameterDefinition_0_3 struct {
 }
 
 type OptionDefinition_0_3 struct {
-	Label string `json:"label"`
-	Value string `json:"value"`
+	Label string      `json:"label"`
+	Value interface{} `json:"value"`
 }
 
 var _ json.Unmarshaler = &OptionDefinition_0_3{}

--- a/pkg/deploy/taskdir/definitions/def_0_3.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3.go
@@ -421,6 +421,7 @@ type ParameterDefinition_0_3 struct {
 	Default     interface{}            `json:"default,omitempty"`
 	Required    *bool                  `json:"required,omitempty"`
 	Options     []OptionDefinition_0_3 `json:"options,omitempty"`
+	Regex       string                 `json:"regex,omitempty"`
 }
 
 type OptionDefinition_0_3 struct {
@@ -667,6 +668,8 @@ func (d Definition_0_3) addParametersToUpdateTaskRequest(ctx context.Context, re
 		if pd.Required != nil && !*pd.Required {
 			param.Constraints.Optional = true
 		}
+
+		param.Constraints.Regex = pd.Regex
 
 		if len(pd.Options) > 0 {
 			param.Constraints.Options = make([]api.ConstraintOption, len(pd.Options))

--- a/pkg/deploy/taskdir/definitions/schema_0_3.json
+++ b/pkg/deploy/taskdir/definitions/schema_0_3.json
@@ -266,6 +266,10 @@
               }
             ]
           }
+        },
+        "regex": {
+          "type": "string",
+          "format": "regex"
         }
       },
       "additionalProperties": false,

--- a/pkg/deploy/taskdir/definitions/schema_0_3.json
+++ b/pkg/deploy/taskdir/definitions/schema_0_3.json
@@ -248,11 +248,19 @@
           "items": {
             "anyOf": [
               { "type": "string" },
+              { "type": "number" },
+              { "type": "boolean" },
               {
                 "type": "object",
                 "properties": {
                   "label": { "type": "string" },
-                  "value": { "type": "string" }
+                  "value": {
+                    "anyOf": [
+                      { "type": "string" },
+                      { "type": "number" },
+                      { "type": "boolean" }
+                    ]
+                  }
                 },
                 "additionalProperties": false
               }
@@ -284,11 +292,11 @@
       "type": "array",
       "items": { "type": "string" }
     },
-	"slug": {
-	  "type": "string",
-	  "pattern": "^[a-z0-9_]+$",
-	  "maxLength": 50
-	},
+    "slug": {
+      "type": "string",
+      "pattern": "^[a-z0-9_]+$",
+      "maxLength": 50
+    },
     "baseDefinition": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
Adds regex, which was missing, & removes string-type constraint from option values.