### PR TITLE
Add SQL runtime

### DIFF
--- a/pkg/build/builder.go
+++ b/pkg/build/builder.go
@@ -298,13 +298,16 @@ const (
 	NameNode       Name = "node"
 	NameDockerfile Name = "dockerfile"
 	NameShell      Name = "shell"
+
+	NameSQL  Name = "sql"
+	NameREST Name = "rest"
 )
 
 func NeedsBuilding(kind TaskKind) (bool, error) {
 	switch Name(kind) {
 	case NameGo, NameDeno, NamePython, NameNode, NameDockerfile, NameShell:
 		return true, nil
-	case NameImage:
+	case NameImage, NameSQL, NameREST:
 		return false, nil
 	default:
 		return false, errors.Errorf("NeedsBuilding got unexpected kind %s", kind)

--- a/pkg/deploy/discover/script_discover.go
+++ b/pkg/deploy/discover/script_discover.go
@@ -10,6 +10,7 @@ import (
 	_ "github.com/airplanedev/lib/pkg/runtime/javascript"
 	_ "github.com/airplanedev/lib/pkg/runtime/python"
 	_ "github.com/airplanedev/lib/pkg/runtime/shell"
+	_ "github.com/airplanedev/lib/pkg/runtime/sql"
 	_ "github.com/airplanedev/lib/pkg/runtime/typescript"
 	"github.com/pkg/errors"
 )

--- a/pkg/runtime/sql/sql.go
+++ b/pkg/runtime/sql/sql.go
@@ -1,0 +1,65 @@
+package sql
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/airplanedev/lib/pkg/build"
+	"github.com/airplanedev/lib/pkg/runtime"
+	"github.com/airplanedev/lib/pkg/utils/logger"
+)
+
+// Init register the runtime.
+func init() {
+	runtime.Register(".sql", Runtime{})
+}
+
+// Code.
+var code = []byte(`-- Add your SQL code here:
+SELECT 1;
+
+-- Define SQL parameters in your definition file:
+-- SELECT * from users where user_id = :user_id;
+`)
+
+// Runtime implementation.
+type Runtime struct{}
+
+// PrepareRun implementation.
+func (r Runtime) PrepareRun(ctx context.Context, logger logger.Logger, opts runtime.PrepareRunOptions) (rexprs []string, rcloser io.Closer, rerr error) {
+	return nil, nil, runtime.ErrNotImplemented
+}
+
+// Generate implementation.
+func (r Runtime) Generate(t *runtime.Task) ([]byte, os.FileMode, error) {
+	return code, 0644, nil
+}
+
+// Workdir implementation.
+func (r Runtime) Workdir(path string) (string, error) {
+	return r.Root(path)
+}
+
+// Root implementation.
+func (r Runtime) Root(path string) (string, error) {
+	return filepath.Dir(path), nil
+}
+
+// Kind implementation.
+func (r Runtime) Kind() build.TaskKind {
+	return build.TaskKindSQL
+}
+
+// FormatComment implementation.
+func (r Runtime) FormatComment(s string) string {
+	var lines []string
+
+	for _, line := range strings.Split(s, "\n") {
+		lines = append(lines, "-- "+line)
+	}
+
+	return strings.Join(lines, "\n")
+}

--- a/pkg/runtime/sql/sql.go
+++ b/pkg/runtime/sql/sql.go
@@ -18,11 +18,9 @@ func init() {
 }
 
 // Code.
-var code = []byte(`-- Add your SQL code here:
+var code = []byte(`-- Add your SQL queries here.
+-- See SQL documentation: https://docs.airplane.dev/creating-tasks/sql
 SELECT 1;
-
--- Define SQL parameters in your definition file:
--- SELECT * from users where user_id = :user_id;
 `)
 
 // Runtime implementation.


### PR DESCRIPTION
Adds a skeleton definition of SQL runtime without local execution. Also adds SQL + REST consideration to NeedsBuilding.

Resolves AIR-2485.