### PR TITLE
Add env parameter to API client

### DIFF
--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -10,7 +10,7 @@ import (
 )
 
 type IAPIClient interface {
-	GetTask(ctx context.Context, slug string) (res Task, err error)
+	GetTask(ctx context.Context, req GetTaskRequest) (res Task, err error)
 	ListResources(ctx context.Context) (res ListResourcesResponse, err error)
 	CreateBuildUpload(ctx context.Context, req CreateBuildUploadRequest) (res CreateBuildUploadResponse, err error)
 	ListGroups(ctx context.Context) (res ListGroupsResponse, err error)
@@ -40,6 +40,11 @@ type Task struct {
 	ExecuteRules               ExecuteRules      `json:"executeRules" yaml:"-"`
 	Timeout                    int               `json:"timeout" yaml:"timeout"`
 	InterpolationMode          string            `json:"interpolationMode" yaml:"-"`
+}
+
+type GetTaskRequest struct {
+	Slug    string
+	EnvSlug string
 }
 
 type CreateBuildUploadRequest struct {

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -80,11 +80,10 @@ type UpdateTaskRequest struct {
 	RequireExplicitPermissions bool              `json:"requireExplicitPermissions"`
 	Permissions                Permissions       `json:"permissions"`
 	ExecuteRules               ExecuteRules      `json:"executeRules"`
-	// TODO(amir): friendly type here (120s, 5m ...)
-	Timeout int     `json:"timeout"`
-	BuildID *string `json:"buildID"`
-
-	InterpolationMode string `json:"interpolationMode" yaml:"-"`
+	Timeout                    int               `json:"timeout"`
+	BuildID                    *string           `json:"buildID"`
+	InterpolationMode          string            `json:"interpolationMode"`
+	EnvSlug                    string            `json:"envSlug"`
 }
 
 type ListResourcesResponse struct {

--- a/pkg/api/mock/client_mock.go
+++ b/pkg/api/mock/client_mock.go
@@ -15,10 +15,10 @@ type MockClient struct {
 
 var _ api.IAPIClient = &MockClient{}
 
-func (mc *MockClient) GetTask(ctx context.Context, slug string) (res api.Task, err error) {
-	task, ok := mc.Tasks[slug]
+func (mc *MockClient) GetTask(ctx context.Context, req api.GetTaskRequest) (res api.Task, err error) {
+	task, ok := mc.Tasks[req.Slug]
 	if !ok {
-		return api.Task{}, &api.TaskMissingError{AppURL: "api/", Slug: slug}
+		return api.Task{}, &api.TaskMissingError{AppURL: "api/", Slug: req.Slug}
 	}
 	return task, nil
 }

--- a/pkg/deploy/discover/discover.go
+++ b/pkg/deploy/discover/discover.go
@@ -86,7 +86,9 @@ func (d *Discoverer) DiscoverTasks(ctx context.Context, paths ...string) ([]Task
 				// The file is not an Airplane task.
 				continue
 			}
-			task, err := d.Client.GetTask(ctx, slug)
+			task, err := d.Client.GetTask(ctx, api.GetTaskRequest{
+				Slug: slug,
+			})
 			if err != nil {
 				var missingErr *api.TaskMissingError
 				if errors.As(err, &missingErr) {

--- a/pkg/deploy/discover/discover.go
+++ b/pkg/deploy/discover/discover.go
@@ -45,6 +45,7 @@ type Discoverer struct {
 	TaskDiscoverers []TaskDiscoverer
 	Client          api.IAPIClient
 	Logger          logger.Logger
+	EnvSlug         string
 }
 
 // DiscoverTasks recursively discovers Airplane tasks.
@@ -87,7 +88,8 @@ func (d *Discoverer) DiscoverTasks(ctx context.Context, paths ...string) ([]Task
 				continue
 			}
 			task, err := d.Client.GetTask(ctx, api.GetTaskRequest{
-				Slug: slug,
+				Slug:    slug,
+				EnvSlug: d.EnvSlug,
 			})
 			if err != nil {
 				var missingErr *api.TaskMissingError

--- a/pkg/deploy/discover/discover.go
+++ b/pkg/deploy/discover/discover.go
@@ -45,12 +45,6 @@ type Discoverer struct {
 	TaskDiscoverers []TaskDiscoverer
 	Client          api.IAPIClient
 	Logger          logger.Logger
-
-	// EnvSlug is the slug of the environment to look for discovered tasks in.
-	//
-	// If a task is discovered, but doesn't exist in this environment, then it will be ignored by
-	// default. Each TaskDiscover can optionally override this behavior.
-	EnvSlug string
 }
 
 // DiscoverTasks recursively discovers Airplane tasks.
@@ -92,10 +86,7 @@ func (d *Discoverer) DiscoverTasks(ctx context.Context, paths ...string) ([]Task
 				// The file is not an Airplane task.
 				continue
 			}
-			task, err := d.Client.GetTask(ctx, api.GetTaskRequest{
-				Slug:    slug,
-				EnvSlug: d.EnvSlug,
-			})
+			task, err := d.Client.GetTask(ctx, slug)
 			if err != nil {
 				var missingErr *api.TaskMissingError
 				if errors.As(err, &missingErr) {

--- a/pkg/deploy/discover/discover.go
+++ b/pkg/deploy/discover/discover.go
@@ -45,7 +45,12 @@ type Discoverer struct {
 	TaskDiscoverers []TaskDiscoverer
 	Client          api.IAPIClient
 	Logger          logger.Logger
-	EnvSlug         string
+
+	// EnvSlug is the slug of the environment to look for discovered tasks in.
+	//
+	// If a task is discovered, but doesn't exist in this environment, then it will be ignored by
+	// default. Each TaskDiscover can optionally override this behavior.
+	EnvSlug string
 }
 
 // DiscoverTasks recursively discovers Airplane tasks.


### PR DESCRIPTION
This PR adds an `envSlug` parameter to the client API (`GetTask` and `UpdateTask`). This [will be used in the CLI](https://github.com/airplanedev/cli/pull/374) and (in a future PR) in the deployer.

cc @ameyakhare 