### PR TITLE
Add EnvSlug to Deployer

### DIFF
--- a/pkg/deploy/discover/discover.go
+++ b/pkg/deploy/discover/discover.go
@@ -45,6 +45,12 @@ type Discoverer struct {
 	TaskDiscoverers []TaskDiscoverer
 	Client          api.IAPIClient
 	Logger          logger.Logger
+
+	// EnvSlug is the slug of the environment to look for discovered tasks in.
+	//
+	// If a task is discovered, but doesn't exist in this environment, then it will be ignored by
+	// default. Each TaskDiscover can optionally override this behavior.
+	EnvSlug string
 }
 
 // DiscoverTasks recursively discovers Airplane tasks.
@@ -87,7 +93,8 @@ func (d *Discoverer) DiscoverTasks(ctx context.Context, paths ...string) ([]Task
 				continue
 			}
 			task, err := d.Client.GetTask(ctx, api.GetTaskRequest{
-				Slug: slug,
+				Slug:    slug,
+				EnvSlug: d.EnvSlug,
 			})
 			if err != nil {
 				var missingErr *api.TaskMissingError

--- a/pkg/deploy/discover/discover.go
+++ b/pkg/deploy/discover/discover.go
@@ -48,8 +48,8 @@ type Discoverer struct {
 
 	// EnvSlug is the slug of the environment to look for discovered tasks in.
 	//
-	// If a task is discovered, but doesn't exist in this environment, then it will be ignored by
-	// default. Each TaskDiscover can optionally override this behavior.
+	// If a task is discovered, but doesn't exist in this environment, then the task
+	// is treated as missing.
 	EnvSlug string
 }
 


### PR DESCRIPTION
This is used by the CLI when deploying into an environment.

I mistakenly removed it from this PR: https://github.com/airplanedev/lib/pull/38#discussion_r796807118