### PR TITLE
Remove unused List{Users,Groups} from API client interface

### DIFF
--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -13,8 +13,6 @@ type IAPIClient interface {
 	GetTask(ctx context.Context, req GetTaskRequest) (res Task, err error)
 	ListResources(ctx context.Context) (res ListResourcesResponse, err error)
 	CreateBuildUpload(ctx context.Context, req CreateBuildUploadRequest) (res CreateBuildUploadResponse, err error)
-	ListGroups(ctx context.Context) (res ListGroupsResponse, err error)
-	ListUsers(ctx context.Context) (res ListUsersResponse, err error)
 }
 
 // Task represents a task.
@@ -308,25 +306,6 @@ func (rc RunConstraints) IsEmpty() bool {
 type AgentLabel struct {
 	Key   string `json:"key" yaml:"key"`
 	Value string `json:"value" yaml:"value"`
-}
-
-type ListGroupsResponse struct {
-	Groups []Group `json:"groups"`
-}
-
-type Group struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
-}
-
-type ListUsersResponse struct {
-	Users []User `json:"users"`
-}
-
-type User struct {
-	ID    string `json:"userID"`
-	Email string `json:"email"`
-	Name  string `json:"name"`
 }
 
 type ExecuteRules struct {

--- a/pkg/api/mock/client_mock.go
+++ b/pkg/api/mock/client_mock.go
@@ -9,8 +9,6 @@ import (
 type MockClient struct {
 	Tasks     map[string]api.Task
 	Resources []api.Resource
-	Users     []api.User
-	Groups    []api.Group
 }
 
 var _ api.IAPIClient = &MockClient{}
@@ -32,17 +30,5 @@ func (mc *MockClient) ListResources(ctx context.Context) (res api.ListResourcesR
 func (mc *MockClient) CreateBuildUpload(ctx context.Context, req api.CreateBuildUploadRequest) (res api.CreateBuildUploadResponse, err error) {
 	return api.CreateBuildUploadResponse{
 		WriteOnlyURL: "writeOnlyURL",
-	}, nil
-}
-
-func (mc *MockClient) ListUsers(ctx context.Context) (res api.ListUsersResponse, err error) {
-	return api.ListUsersResponse{
-		Users: mc.Users,
-	}, nil
-}
-
-func (mc *MockClient) ListGroups(ctx context.Context) (res api.ListGroupsResponse, err error) {
-	return api.ListGroupsResponse{
-		Groups: mc.Groups,
 	}, nil
 }

--- a/pkg/deploy/taskdir/definitions/def_0_3_test.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3_test.go
@@ -218,8 +218,6 @@ func TestTaskToDefinition_0_3(t *testing.T) {
 		task       api.Task
 		definition Definition_0_3
 		resources  []api.Resource
-		users      []api.User
-		groups     []api.Group
 	}{
 		{
 			name: "python task",
@@ -541,8 +539,6 @@ func TestTaskToDefinition_0_3(t *testing.T) {
 			ctx := context.Background()
 			client := &mock.MockClient{
 				Resources: test.resources,
-				Users:     test.users,
-				Groups:    test.groups,
 			}
 			d, err := NewDefinitionFromTask_0_3(ctx, client, test.task)
 			assert.NoError(err)
@@ -556,8 +552,6 @@ func TestDefinitionToUpdateTaskRequest_0_3(t *testing.T) {
 		name       string
 		definition Definition_0_3
 		request    api.UpdateTaskRequest
-		users      []api.User
-		groups     []api.Group
 	}{
 		{
 			name: "python task",
@@ -709,10 +703,7 @@ func TestDefinitionToUpdateTaskRequest_0_3(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			assert := require.New(t)
 			ctx := context.Background()
-			client := &mock.MockClient{
-				Users:  test.users,
-				Groups: test.groups,
-			}
+			client := &mock.MockClient{}
 			req, err := test.definition.GetUpdateTaskRequest(ctx, client, &api.Task{})
 			assert.NoError(err)
 			assert.Equal(test.request, req)


### PR DESCRIPTION
This is dead code since tasks-as-code doesn't deal with permissions anymore.