### PR TITLE
Copy execute rules over correctly

### DIFF
--- a/pkg/deploy/taskdir/definitions/def_0_3.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3.go
@@ -872,6 +872,7 @@ func (d Definition_0_3) GetUpdateTaskRequest(ctx context.Context, client api.IAP
 	if currentTask != nil {
 		req.RequireExplicitPermissions = currentTask.RequireExplicitPermissions
 		req.Permissions = currentTask.Permissions
+		req.ExecuteRules = currentTask.ExecuteRules
 	}
 
 	return req, nil

--- a/pkg/deploy/taskdir/definitions/definitions.go
+++ b/pkg/deploy/taskdir/definitions/definitions.go
@@ -297,9 +297,11 @@ func (def *Definition) GetUpdateTaskRequest(ctx context.Context, client api.IAPI
 		Repo:             def.Repo,
 		Timeout:          def.Timeout,
 	}
+
 	if currentTask != nil {
 		utr.Permissions = currentTask.Permissions
 		utr.RequireExplicitPermissions = currentTask.RequireExplicitPermissions
+		utr.ExecuteRules = currentTask.ExecuteRules
 	}
 	return utr, nil
 }


### PR DESCRIPTION
Needs upgrading CLI after this too, the existing version will continue to wipe `executeRules` and I'm not sure if we can handle it correctly on the API side short of creating a new field entirely

---
cc @francescaleung @joshma 