### PR TITLE
Handle the same task being discovered by multiple discoverers

### DIFF
--- a/pkg/deploy/discover/discover_test.go
+++ b/pkg/deploy/discover/discover_test.go
@@ -27,7 +27,7 @@ func TestDiscoverTasks(t *testing.T) {
 			name:  "single script",
 			paths: []string{"./fixtures/single_task.js"},
 			existingTasks: map[string]api.Task{
-				"my_task": {Kind: build.TaskKindNode},
+				"my_task": {Slug: "my_task", Kind: build.TaskKindNode},
 			},
 			want: []TaskConfig{
 				{
@@ -35,9 +35,10 @@ func TestDiscoverTasks(t *testing.T) {
 					WorkingDirectory: fixturesPath,
 					TaskEntrypoint:   fixturesPath + "/single_task.js",
 					Def: &definitions.Definition{
+						Slug: "my_task",
 						Node: &definitions.NodeDefinition{Entrypoint: "single_task.js"},
 					},
-					Task: api.Task{Kind: build.TaskKindNode},
+					Task: api.Task{Slug: "my_task", Kind: build.TaskKindNode},
 					From: TaskConfigSourceScript,
 				},
 			},
@@ -46,8 +47,8 @@ func TestDiscoverTasks(t *testing.T) {
 			name:  "multiple scripts",
 			paths: []string{"./fixtures/single_task.js", "./fixtures/single_task2.js"},
 			existingTasks: map[string]api.Task{
-				"my_task":  {Kind: build.TaskKindNode},
-				"my_task2": {Kind: build.TaskKindNode},
+				"my_task":  {Slug: "my_task", Kind: build.TaskKindNode},
+				"my_task2": {Slug: "my_task2", Kind: build.TaskKindNode},
 			},
 			want: []TaskConfig{
 				{
@@ -55,9 +56,10 @@ func TestDiscoverTasks(t *testing.T) {
 					WorkingDirectory: fixturesPath,
 					TaskEntrypoint:   fixturesPath + "/single_task.js",
 					Def: &definitions.Definition{
+						Slug: "my_task",
 						Node: &definitions.NodeDefinition{Entrypoint: "single_task.js"},
 					},
-					Task: api.Task{Kind: build.TaskKindNode},
+					Task: api.Task{Slug: "my_task", Kind: build.TaskKindNode},
 					From: TaskConfigSourceScript,
 				},
 				{
@@ -65,9 +67,10 @@ func TestDiscoverTasks(t *testing.T) {
 					WorkingDirectory: fixturesPath,
 					TaskEntrypoint:   fixturesPath + "/single_task2.js",
 					Def: &definitions.Definition{
+						Slug: "my_task2",
 						Node: &definitions.NodeDefinition{Entrypoint: "single_task2.js"},
 					},
-					Task: api.Task{Kind: build.TaskKindNode},
+					Task: api.Task{Slug: "my_task2", Kind: build.TaskKindNode},
 					From: TaskConfigSourceScript,
 				},
 			},
@@ -76,8 +79,8 @@ func TestDiscoverTasks(t *testing.T) {
 			name:  "nested scripts",
 			paths: []string{"./fixtures/nestedScripts"},
 			existingTasks: map[string]api.Task{
-				"my_task":  {Kind: build.TaskKindNode},
-				"my_task2": {Kind: build.TaskKindNode},
+				"my_task":  {Slug: "my_task", Kind: build.TaskKindNode},
+				"my_task2": {Slug: "my_task2", Kind: build.TaskKindNode},
 			},
 			want: []TaskConfig{
 				{
@@ -85,9 +88,10 @@ func TestDiscoverTasks(t *testing.T) {
 					WorkingDirectory: fixturesPath + "/nestedScripts",
 					TaskEntrypoint:   fixturesPath + "/nestedScripts/single_task.js",
 					Def: &definitions.Definition{
+						Slug: "my_task",
 						Node: &definitions.NodeDefinition{Entrypoint: "single_task.js"},
 					},
-					Task: api.Task{Kind: build.TaskKindNode},
+					Task: api.Task{Slug: "my_task", Kind: build.TaskKindNode},
 					From: TaskConfigSourceScript,
 				},
 				{
@@ -95,9 +99,10 @@ func TestDiscoverTasks(t *testing.T) {
 					WorkingDirectory: fixturesPath + "/nestedScripts",
 					TaskEntrypoint:   fixturesPath + "/nestedScripts/single_task2.js",
 					Def: &definitions.Definition{
+						Slug: "my_task2",
 						Node: &definitions.NodeDefinition{Entrypoint: "single_task2.js"},
 					},
-					Task: api.Task{Kind: build.TaskKindNode},
+					Task: api.Task{Slug: "my_task2", Kind: build.TaskKindNode},
 					From: TaskConfigSourceScript,
 				},
 			},
@@ -106,7 +111,7 @@ func TestDiscoverTasks(t *testing.T) {
 			name:  "single defn",
 			paths: []string{"./fixtures/defn.task.yaml"},
 			existingTasks: map[string]api.Task{
-				"my_task": {Kind: build.TaskKindNode},
+				"my_task": {Slug: "my_task", Kind: build.TaskKindNode},
 			},
 			want: []TaskConfig{
 				{
@@ -120,7 +125,7 @@ func TestDiscoverTasks(t *testing.T) {
 						// TODO adjust to be absolute path
 						Node: &definitions.NodeDefinition_0_3{Entrypoint: "./single_task.js", NodeVersion: "14"},
 					},
-					Task: api.Task{Kind: build.TaskKindNode},
+					Task: api.Task{Slug: "my_task", Kind: build.TaskKindNode},
 					From: TaskConfigSourceDefn,
 				},
 			},
@@ -130,6 +135,29 @@ func TestDiscoverTasks(t *testing.T) {
 			paths:         []string{"./fixtures/single_task.js", "./fixtures/defn.task.yaml"},
 			existingTasks: map[string]api.Task{},
 			expectedErr:   false,
+		},
+		{
+			name:  "same task, multiple discoverers",
+			paths: []string{"./fixtures/defn.task.yaml", "./fixtures/single_task.js"},
+			existingTasks: map[string]api.Task{
+				"my_task": {Slug: "my_task", Kind: build.TaskKindNode},
+			},
+			want: []TaskConfig{
+				{
+					TaskRoot: fixturesPath,
+					// TODO adjust to be fixturesPath when entrypoint is relative to task defn
+					TaskEntrypoint: discoverPath + "/single_task.js",
+					Def: &definitions.Definition_0_3{
+						Name:        "sunt in tempor eu",
+						Slug:        "my_task",
+						Description: "ut dolor sit officia ea",
+						// TODO adjust to be absolute path
+						Node: &definitions.NodeDefinition_0_3{Entrypoint: "./single_task.js", NodeVersion: "14"},
+					},
+					Task: api.Task{Slug: "my_task", Kind: build.TaskKindNode},
+					From: TaskConfigSourceDefn,
+				},
+			},
 		},
 	}
 	for _, tC := range tests {
@@ -143,7 +171,7 @@ func TestDiscoverTasks(t *testing.T) {
 				Client: apiClient,
 			}
 			d := &Discoverer{
-				TaskDiscoverers: []TaskDiscoverer{scriptDiscoverer, defnDiscoverer},
+				TaskDiscoverers: []TaskDiscoverer{defnDiscoverer, scriptDiscoverer},
 				Client: &mock.MockClient{
 					Tasks: tC.existingTasks,
 				},


### PR DESCRIPTION
Returns a single task config per slug, in order of discoverers, in order of discovery. E.g.: given discoverers [DefnDiscoverer, ScriptDiscoverer], if task `my_task` has both a linked script & a defn file, the defn file will take precedence; given two defn files for the same task, the first defn file to be discovered takes precedence.

Resolves AIR-2973.