### PR TITLE
Fix REST types for URLParams, Headers, & FormData

### DIFF
--- a/pkg/deploy/taskdir/definitions/def_0_3.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3.go
@@ -545,8 +545,8 @@ type RESTDefinition_0_3 struct {
 	Resource  string                 `json:"resource"`
 	Method    string                 `json:"method"`
 	Path      string                 `json:"path"`
-	URLParams map[string]string      `json:"urlParams,omitempty"`
-	Headers   map[string]string      `json:"headers,omitempty"`
+	URLParams map[string]interface{} `json:"urlParams,omitempty"`
+	Headers   map[string]interface{} `json:"headers,omitempty"`
 	BodyType  string                 `json:"bodyType"`
 	Body      string                 `json:"body,omitempty"`
 	FormData  map[string]interface{} `json:"formData,omitempty"`
@@ -592,14 +592,14 @@ func (d *RESTDefinition_0_3) hydrateFromTask(ctx context.Context, client api.IAP
 		}
 	}
 	if v, ok := t.KindOptions["urlParams"]; ok {
-		if mv, ok := v.(map[string]string); ok {
+		if mv, ok := v.(map[string]interface{}); ok {
 			d.URLParams = mv
 		} else {
 			return errors.Errorf("expected map urlParams, got %T instead", v)
 		}
 	}
 	if v, ok := t.KindOptions["headers"]; ok {
-		if mv, ok := v.(map[string]string); ok {
+		if mv, ok := v.(map[string]interface{}); ok {
 			d.Headers = mv
 		} else {
 			return errors.Errorf("expected map headers, got %T instead", v)

--- a/pkg/deploy/taskdir/definitions/schema_0_3.json
+++ b/pkg/deploy/taskdir/definitions/schema_0_3.json
@@ -190,11 +190,15 @@
                 "path": { "type": "string" },
                 "urlParams": {
                   "type": "object",
-                  "patternProperties": { ".*": { "type": "string" } }
+                  "patternProperties": {
+                    ".*": { "type": ["string", "boolean", "number"] }
+                  }
                 },
                 "headers": {
                   "type": "object",
-                  "patternProperties": { ".*": { "type": "string" } }
+                  "patternProperties": {
+                    ".*": { "type": ["string", "boolean", "number"] }
+                  }
                 },
                 "bodyType": {
                   "enum": ["json", "raw", "form-data", "x-www-form-urlencoded"]
@@ -202,7 +206,9 @@
                 "body": { "type": "string" },
                 "formData": {
                   "type": "object",
-                  "patternProperties": { ".*": { "type": "string" } }
+                  "patternProperties": {
+                    ".*": { "type": ["string", "boolean", "number"] }
+                  }
                 }
               },
               "additionalProperties": false,


### PR DESCRIPTION
This matches the types we have in the API. REST tasks run into type assertion errors otherwise.