### PR TITLE
Remove Workdir from NodeDef03

### DIFF
--- a/pkg/deploy/discover/discover_test.go
+++ b/pkg/deploy/discover/discover_test.go
@@ -253,62 +253,6 @@ func TestDiscoverTasks(t *testing.T) {
 				},
 			},
 		},
-		{
-			name:  "different working directory",
-			paths: []string{"./fixtures/subdir/single_task.js"},
-			existingTasks: map[string]api.Task{
-				"my_task": {Slug: "my_task", Kind: build.TaskKindNode},
-			},
-			want: []TaskConfig{
-				{
-					TaskRoot:       fixturesPath,
-					TaskEntrypoint: fixturesPath + "/subdir/single_task.js",
-					Def: &definitions.Definition{
-						Slug: "my_task",
-						Node: &definitions.NodeDefinition{
-							Entrypoint: "subdir/single_task.js",
-						},
-					},
-					Task: api.Task{Slug: "my_task", Kind: build.TaskKindNode},
-					From: TaskConfigSourceScript,
-				},
-			},
-			buildConfigs: []build.BuildConfig{
-				{
-					"workdir": "/subdir",
-				},
-			},
-		},
-		{
-			name:  "different working directory, with definition",
-			paths: []string{"./fixtures/subdir/defn.task.yaml"},
-			existingTasks: map[string]api.Task{
-				"my_task": {Slug: "my_task", Kind: build.TaskKindNode},
-			},
-			want: []TaskConfig{
-				{
-					TaskRoot:       fixturesPath,
-					TaskEntrypoint: fixturesPath + "/subdir/single_task.js",
-					Def: &definitions.Definition_0_3{
-						Name:        "sunt in tempor eu",
-						Slug:        "my_task",
-						Description: "ut dolor sit officia ea",
-						Node: &definitions.NodeDefinition_0_3{
-							Entrypoint:  "./single_task.js",
-							NodeVersion: "14",
-						},
-					},
-					Task: api.Task{Slug: "my_task", Kind: build.TaskKindNode},
-					From: TaskConfigSourceDefn,
-				},
-			},
-			buildConfigs: []build.BuildConfig{
-				{
-					"workdir":    "/subdir",
-					"entrypoint": "subdir/single_task.js",
-				},
-			},
-		},
 	}
 	for _, tC := range tests {
 		t.Run(tC.name, func(t *testing.T) {

--- a/pkg/deploy/taskdir/definitions/def_0_3.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3.go
@@ -270,7 +270,6 @@ func (d *GoDefinition_0_3) getEnv() (api.TaskEnv, error) {
 var _ taskKind_0_3 = &NodeDefinition_0_3{}
 
 type NodeDefinition_0_3 struct {
-	Workdir     string      `json:"-"`
 	Entrypoint  string      `json:"entrypoint"`
 	NodeVersion string      `json:"nodeVersion"`
 	Arguments   []string    `json:"arguments,omitempty"`
@@ -285,13 +284,6 @@ func (d *NodeDefinition_0_3) fillInUpdateTaskRequest(ctx context.Context, client
 
 func (d *NodeDefinition_0_3) hydrateFromTask(ctx context.Context, client api.IAPIClient, t *api.Task) error {
 	d.Arguments = t.Arguments
-	if v, ok := t.KindOptions["workdir"]; ok {
-		if sv, ok := v.(string); ok {
-			d.Workdir = sv
-		} else {
-			return errors.Errorf("expected string workdir, got %T instead", v)
-		}
-	}
 	if v, ok := t.KindOptions["entrypoint"]; ok {
 		if sv, ok := v.(string); ok {
 			d.Entrypoint = sv
@@ -321,7 +313,6 @@ func (d *NodeDefinition_0_3) upgradeJST() error {
 
 func (d *NodeDefinition_0_3) getKindOptions() (build.KindOptions, error) {
 	return build.KindOptions{
-		"workdir":     d.Workdir, // should only be part of BuildOptions
 		"entrypoint":  d.Entrypoint,
 		"nodeVersion": d.NodeVersion,
 	}, nil

--- a/pkg/deploy/taskdir/definitions/def_0_3_test.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3_test.go
@@ -596,7 +596,6 @@ func TestDefinitionToUpdateTaskRequest_0_3(t *testing.T) {
 				KindOptions: build.KindOptions{
 					"entrypoint":  "main.ts",
 					"nodeVersion": "14",
-					"workdir":     "",
 				},
 			},
 		},


### PR DESCRIPTION
Got lost somewhere in merges & reshuffling. Workdir is now being handled through build config, not kind options.