### PR TITLE
Show better schema errors

### DIFF
--- a/pkg/deploy/taskdir/definitions/error.go
+++ b/pkg/deploy/taskdir/definitions/error.go
@@ -1,0 +1,37 @@
+package definitions
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+const taskDefDocURL = "https://docs.airplane.dev/deprecated/task-definition-reference"
+
+type errReadDefinition struct {
+	msg       string
+	errorMsgs []string
+}
+
+func NewErrReadDefinition(msg string, errorMsgs ...string) error {
+	return errors.WithStack(errReadDefinition{
+		msg:       msg,
+		errorMsgs: errorMsgs,
+	})
+}
+
+func (err errReadDefinition) Error() string {
+	return err.msg
+}
+
+// Implements ErrorExplained
+func (err errReadDefinition) ExplainError() string {
+	msgs := []string{}
+	msgs = append(msgs, err.errorMsgs...)
+	if len(err.errorMsgs) > 0 {
+		msgs = append(msgs, "")
+	}
+	msgs = append(msgs, fmt.Sprintf("For more information on the task definition format, see the docs:\n%s", taskDefDocURL))
+	return strings.Join(msgs, "\n")
+}

--- a/pkg/deploy/taskdir/definitions/schema_0_3.json
+++ b/pkg/deploy/taskdir/definitions/schema_0_3.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Task",
   "oneOf": [
     {
@@ -220,6 +221,27 @@
       ]
     }
   ],
+  "properties": {
+    "name": true,
+    "slug": true,
+    "description": true,
+    "parameters": true,
+    "constraints": true,
+    "requireRequests": true,
+    "allowSelfApprovals": true,
+    "timeout": true,
+
+    "node": true,
+    "python": true,
+    "shell": true,
+    "image": true,
+    "deno": true,
+    "go": true,
+    "dockerfile": true,
+    "sql": true,
+    "rest": true
+  },
+  "additionalProperties": false,
 
   "$defs": {
     "parameter": {


### PR DESCRIPTION
This brings back `errReadDefinition` to tell users why their schema is failing.

Before:
```
Error: Invalid format: [(root): Must validate one and only one schema (oneOf) timeout: Invalid type. Expected: number, given: string (root): Must validate all the schemas (allOf)]
```

After:
```
(root): Must validate one and only one schema (oneOf)
timeout: Invalid type. Expected: number, given: string
image: image is required
(root): Must validate all the schemas (allOf)

For more information on the task definition format, see the docs:
https://docs.airplane.dev/deprecated/task-definition-reference
```

(We'll need to update the task defn link!)

The change to the schema is to pin the schema to a particular JSON schema draft, & also to put a restriction on additional properties.

Resolves AIR-3062.