### PR TITLE
Add SupportsLocalExecution to Runtime interface

### DIFF
--- a/pkg/runtime/javascript/javascript.go
+++ b/pkg/runtime/javascript/javascript.go
@@ -237,6 +237,11 @@ func (r Runtime) PrepareRun(ctx context.Context, logger logger.Logger, opts runt
 	return []string{"node", res.OutputFiles[0].Path, string(pv)}, closer, nil
 }
 
+// SupportsLocalExecution implementation.
+func (r Runtime) SupportsLocalExecution() bool {
+	return true
+}
+
 // checkNodeVersion compares the major version of the currently installed
 // node binary with that of the configured task and logs a warning if they
 // do not match.

--- a/pkg/runtime/python/python.go
+++ b/pkg/runtime/python/python.go
@@ -192,3 +192,8 @@ func (r Runtime) FormatComment(s string) string {
 
 	return strings.Join(lines, "\n")
 }
+
+// SupportsLocalExecution implementation.
+func (r Runtime) SupportsLocalExecution() bool {
+	return true
+}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -78,6 +78,10 @@ type Interface interface {
 	// If running the script locally is not supported the method returns
 	// an `ErrNotImplemented`.
 	PrepareRun(ctx context.Context, logger logger.Logger, opts PrepareRunOptions) (rexprs []string, closer io.Closer, err error)
+
+	// SupportsLocalExecution returns true if PrepareRun does not return
+	// `ErrNotImplemented`.
+	SupportsLocalExecution() bool
 }
 
 type PrepareRunOptions struct {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -79,8 +79,8 @@ type Interface interface {
 	// an `ErrNotImplemented`.
 	PrepareRun(ctx context.Context, logger logger.Logger, opts PrepareRunOptions) (rexprs []string, closer io.Closer, err error)
 
-	// SupportsLocalExecution returns true if PrepareRun does not return
-	// `ErrNotImplemented`.
+	// SupportsLocalExecution returns true if local execution is supported.
+	// This is expected to match whether PrepareRun returns `ErrNotImplemented`.
 	SupportsLocalExecution() bool
 }
 

--- a/pkg/runtime/shell/shell.go
+++ b/pkg/runtime/shell/shell.go
@@ -150,6 +150,11 @@ func (r Runtime) FormatComment(s string) string {
 	return strings.Join(lines, "\n")
 }
 
+// SupportsLocalExecution implementation.
+func (r Runtime) SupportsLocalExecution() bool {
+	return true
+}
+
 // checkAndPromptFileExecutable checks that a file is executable. If it isn't, it prompts the user to make it
 // executable. Returns an error if the file is not executable.
 func checkAndPromptFileExecutable(path string) error {

--- a/pkg/runtime/sql/sql.go
+++ b/pkg/runtime/sql/sql.go
@@ -61,3 +61,8 @@ func (r Runtime) FormatComment(s string) string {
 
 	return strings.Join(lines, "\n")
 }
+
+// SupportsLocalExecution implementation.
+func (r Runtime) SupportsLocalExecution() bool {
+	return false
+}


### PR DESCRIPTION
Shortcut to if `PrepareRun` returns `ErrNotImplemented`.

Supports AIR-3060, AIR-3061.