### PR TITLE
Remove maximum constraint from timeout in schema

### DIFF
--- a/pkg/deploy/taskdir/definitions/schema_0_3.json
+++ b/pkg/deploy/taskdir/definitions/schema_0_3.json
@@ -332,7 +332,6 @@
         "allowSelfApprovals": { "type": "boolean" },
         "timeout": {
           "type": "number",
-          "maximum": 3600,
           "exclusiveMinimum": 0
         }
       },


### PR DESCRIPTION
Opting to remove this rather than double-implement maximums.

Resolves AIR-3136.