### PR TITLE
Fix entrypoint for image definition

### DIFF
--- a/pkg/deploy/taskdir/definitions/def_0_3.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3.go
@@ -59,8 +59,6 @@ type ImageDefinition_0_3 struct {
 	Entrypoint string      `json:"entrypoint,omitempty"`
 	Command    []string    `json:"command"`
 	EnvVars    api.TaskEnv `json:"envVars,omitempty"`
-
-	absoluteEntrypoint string `json:"-"`
 }
 
 func (d *ImageDefinition_0_3) fillInUpdateTaskRequest(ctx context.Context, client api.IAPIClient, req *api.UpdateTaskRequest) error {
@@ -86,20 +84,15 @@ func (d *ImageDefinition_0_3) hydrateFromTask(ctx context.Context, client api.IA
 }
 
 func (d *ImageDefinition_0_3) setEntrypoint(entrypoint string) error {
-	d.Entrypoint = entrypoint
-	return nil
+	return ErrNoEntrypoint
 }
 
 func (d *ImageDefinition_0_3) setAbsoluteEntrypoint(entrypoint string) error {
-	d.absoluteEntrypoint = entrypoint
-	return nil
+	return ErrNoEntrypoint
 }
 
 func (d *ImageDefinition_0_3) getAbsoluteEntrypoint() (string, error) {
-	if d.absoluteEntrypoint == "" {
-		return "", ErrNoAbsoluteEntrypoint
-	}
-	return d.absoluteEntrypoint, nil
+	return "", ErrNoEntrypoint
 }
 
 func (d *ImageDefinition_0_3) getKindOptions() (build.KindOptions, error) {


### PR DESCRIPTION
Confusingly, image definitions have an "entrypoint" field that is different from the "entrypoint" field for other definitions. Unlike, say, a Python definition, an image definition's entrypoint is not a script, but an instruction to Docker to override the default image entrypoint. All entrypoint-related functions on definitions & task kind definitions are of the script variety, & so technically image definitions don't have entrypoints. This is correct for `getEntrypoint()`, but was incorrect for `setEntrypoint()` & `{set,get}AbsoluteEntrypoint()`.