### PR TITLE
Add comments to generated YAML file

### DIFF
--- a/pkg/deploy/taskdir/definitions/def_0_3.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3.go
@@ -174,10 +174,13 @@ func (d Definition_0_3) getCommentMap() (yaml.CommentMap, []byte, error) {
 	}
 
 	addComment(comment{
-		key:     "$.constraints",
-		doAdd:   d.Constraints != nil && !d.Constraints.IsEmpty(),
-		example: ``,
-		text:    "",
+		key:   "$.constraints",
+		doAdd: d.Constraints != nil && !d.Constraints.IsEmpty(),
+		example: `constraints:
+  labels:
+  - key: aws-region
+    value: us-west-2`,
+		text: "Set label constraints to restrict this task to run only on agents with matching labels.",
 	})
 	addComment(comment{
 		key:     "$.requireRequests",

--- a/pkg/deploy/taskdir/definitions/def_0_3.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3.go
@@ -45,7 +45,7 @@ type Definition_0_3 struct {
 
 func (d Definition_0_3) getCommentMap() (yaml.CommentMap, []byte, error) {
 	cm := yaml.CommentMap{
-		"$.slug": yaml.HeadComment(" This is how Airplane identifies your task."),
+		"$.slug": yaml.HeadComment(" Used by Airplane to identify your task. Do not change."),
 		"$.name": yaml.HeadComment(" A human-readable name for your task."),
 	}
 

--- a/pkg/deploy/taskdir/definitions/def_0_3.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/airplanedev/lib/pkg/api"
 	"github.com/airplanedev/lib/pkg/build"
+	"github.com/airplanedev/lib/pkg/utils"
 	"github.com/alessio/shellescape"
 	"github.com/flynn/go-shlex"
 	"github.com/goccy/go-yaml"
@@ -53,7 +54,9 @@ func (d Definition_0_3) getCommentMap() (yaml.CommentMap, []byte, error) {
 	addComment := func(key string, doAdd bool, example string, comment ...string) {
 		nextComments = append(nextComments, "")
 		for _, c := range comment {
-			nextComments = append(nextComments, " "+c)
+			for _, l := range utils.BreakLines(c, 78) {
+				nextComments = append(nextComments, " "+l)
+			}
 		}
 		if doAdd {
 			cm[key] = yaml.HeadComment(nextComments...)

--- a/pkg/deploy/taskdir/definitions/def_0_3.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3.go
@@ -85,6 +85,7 @@ func (d Definition_0_3) getCommentMap() (yaml.CommentMap, []byte, error) {
 		example: `description: This is a new task.`,
 		text:    "A human-readable description for your task. Supports Markdown.",
 	})
+	// TODO: flesh this one out
 	addComment(comment{
 		key:   "$.parameters",
 		doAdd: len(d.Parameters) > 0,
@@ -132,30 +133,35 @@ func (d Definition_0_3) getCommentMap() (yaml.CommentMap, []byte, error) {
 			doAdd: true,
 			text:  "Configuration for a Node task.",
 		})
+		// TODO: Documentation for Node-specific options.
 	case build.TaskKindPython:
 		addComment(comment{
 			key:   "$.python",
 			doAdd: true,
 			text:  "Configuration for a Python task.",
 		})
+		// TODO: Documentation for Python-specific options.
 	case build.TaskKindShell:
 		addComment(comment{
 			key:   "$.shell",
 			doAdd: true,
 			text:  "Configuration for a shell task.",
 		})
+		// TODO: Documentation for shell-specific options.
 	case build.TaskKindSQL:
 		addComment(comment{
 			key:   "$.sql",
 			doAdd: true,
 			text:  "Configuration for a SQL task.",
 		})
+		// TODO: Documentation for SQL-specific options.
 	case build.TaskKindREST:
 		addComment(comment{
 			key:   "$.rest",
 			doAdd: true,
 			text:  "Configuration for a REST task.",
 		})
+		// TODO: Documentation for REST-specific options.
 	default:
 		return yaml.CommentMap{}, nil, errors.Errorf("unknown task kind: %s", kind)
 	}

--- a/pkg/utils/strings.go
+++ b/pkg/utils/strings.go
@@ -1,0 +1,26 @@
+package utils
+
+import (
+	"strings"
+	"unicode"
+)
+
+func BreakLines(line string, lineLength int) []string {
+	start := 0
+	lastWhitespaceIdx := 0
+	lines := []string{}
+	for i, r := range line {
+		if unicode.IsSpace(r) {
+			if lastWhitespaceIdx == i-1 && start == lastWhitespaceIdx {
+				start = i
+			}
+			lastWhitespaceIdx = i
+		}
+		if i-start > lineLength && lastWhitespaceIdx > start {
+			lines = append(lines, strings.TrimSpace(line[start:lastWhitespaceIdx]))
+			start = lastWhitespaceIdx
+		}
+	}
+	lines = append(lines, strings.TrimSpace(line[start:]))
+	return lines
+}

--- a/pkg/utils/strings.go
+++ b/pkg/utils/strings.go
@@ -7,7 +7,7 @@ import (
 
 func BreakLines(line string, lineLength int) []string {
 	start := 0
-	lastWhitespaceIdx := 0
+	lastWhitespaceIdx := -1
 	lines := []string{}
 	for i, r := range line {
 		if unicode.IsSpace(r) {

--- a/pkg/utils/strings_test.go
+++ b/pkg/utils/strings_test.go
@@ -61,6 +61,12 @@ func TestBreakLines(tt *testing.T) {
 				"whitespace.",
 			},
 		},
+		{
+			name:     "start with a one-character word",
+			line:     "A line with a one-character word",
+			length:   100,
+			expected: []string{"A line with a one-character word"},
+		},
 	} {
 		tt.Run(test.name, func(t *testing.T) {
 			assert := require.New(t)

--- a/pkg/utils/strings_test.go
+++ b/pkg/utils/strings_test.go
@@ -1,0 +1,71 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBreakLines(tt *testing.T) {
+	for _, test := range []struct {
+		name     string
+		line     string
+		length   int
+		expected []string
+	}{
+		{
+			name:   "short",
+			line:   "This is a line",
+			length: 20,
+			expected: []string{
+				"This is a line",
+			},
+		},
+		{
+			name:   "long",
+			line:   "This is a long line",
+			length: 10,
+			expected: []string{
+				"This is a",
+				"long line",
+			},
+		},
+		{
+			name:   "word size exceeds line length",
+			line:   "This line has a long word: abcdefghijklmnopqrstuvwxyz",
+			length: 20,
+			expected: []string{
+				"This line has a long",
+				"word:",
+				"abcdefghijklmnopqrstuvwxyz",
+			},
+		},
+		{
+			name:   "word size exceeds line length but in the middle",
+			line:   "This is a line. abcdefghijklmnopqrstuvwxyz is a really long word.",
+			length: 20,
+			expected: []string{
+				"This is a line.",
+				"abcdefghijklmnopqrstuvwxyz",
+				"is a really long",
+				"word.",
+			},
+		},
+		{
+			name:   "lots o spaces",
+			line:   "This  line    has a          lot  of   extra    whitespace.",
+			length: 20,
+			expected: []string{
+				"This  line    has a",
+				"lot  of   extra",
+				"whitespace.",
+			},
+		},
+	} {
+		tt.Run(test.name, func(t *testing.T) {
+			assert := require.New(t)
+			lines := BreakLines(test.line, test.length)
+			assert.Equal(test.expected, lines)
+		})
+	}
+}


### PR DESCRIPTION
There needs to be another pass for copy, but this pass is for the generation part. It's somewhat ugly & the end result is less than ideal, but short of switching libraries (again!) this might be the best we could do.

Resolves AIR-3174.