### PR TITLE
Simplify schema

### DIFF
--- a/pkg/deploy/taskdir/definitions/def_0_3.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3.go
@@ -753,7 +753,7 @@ func NewDefinition_0_3(name string, slug string, kind build.TaskKind, entrypoint
 	case build.TaskKindImage:
 		def.Image = &ImageDefinition_0_3{
 			Image:   "alpine:3",
-			Command: []string{"echo", "hello world"},
+			Command: `echo "hello world"`,
 		}
 	case build.TaskKindNode:
 		def.Node = &NodeDefinition_0_3{

--- a/pkg/deploy/taskdir/definitions/def_0_3.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3.go
@@ -57,7 +57,7 @@ var _ taskKind_0_3 = &ImageDefinition_0_3{}
 type ImageDefinition_0_3 struct {
 	Image      string      `json:"image"`
 	Entrypoint string      `json:"entrypoint,omitempty"`
-	Command    []string    `json:"command"`
+	Command    string      `json:"command"`
 	EnvVars    api.TaskEnv `json:"envVars,omitempty"`
 }
 
@@ -65,7 +65,11 @@ func (d *ImageDefinition_0_3) fillInUpdateTaskRequest(ctx context.Context, clien
 	if d.Image != "" {
 		req.Image = &d.Image
 	}
-	req.Arguments = d.Command
+	if args, err := shlex.Split(d.Command); err != nil {
+		return err
+	} else {
+		req.Arguments = args
+	}
 	if cmd, err := shlex.Split(d.Entrypoint); err != nil {
 		return err
 	} else {
@@ -78,7 +82,7 @@ func (d *ImageDefinition_0_3) hydrateFromTask(ctx context.Context, client api.IA
 	if t.Image != nil {
 		d.Image = *t.Image
 	}
-	d.Command = t.Arguments
+	d.Command = shellescape.QuoteCommand(t.Arguments)
 	d.Entrypoint = shellescape.QuoteCommand(t.Command)
 	return nil
 }

--- a/pkg/deploy/taskdir/definitions/def_0_3.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3.go
@@ -909,7 +909,7 @@ func (d Definition_0_3) GetUpdateTaskRequest(ctx context.Context, client api.IAP
 		return api.UpdateTaskRequest{}, err
 	}
 
-	if d.Constraints != nil {
+	if len(d.Constraints) > 0 {
 		labels := []api.AgentLabel{}
 		for key, val := range d.Constraints {
 			labels = append(labels, api.AgentLabel{
@@ -1101,9 +1101,11 @@ func NewDefinitionFromTask_0_3(ctx context.Context, client api.IAPIClient, t api
 		return Definition_0_3{}, err
 	}
 
-	d.Constraints = map[string]string{}
-	for _, label := range t.Constraints.Labels {
-		d.Constraints[label.Key] = label.Value
+	if !t.Constraints.IsEmpty() {
+		d.Constraints = map[string]string{}
+		for _, label := range t.Constraints.Labels {
+			d.Constraints[label.Key] = label.Value
+		}
 	}
 
 	if t.ExecuteRules.DisallowSelfApprove {

--- a/pkg/deploy/taskdir/definitions/def_0_3.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3.go
@@ -25,7 +25,7 @@ type Definition_0_3 struct {
 	Deno       *DenoDefinition_0_3       `json:"deno,omitempty"`
 	Dockerfile *DockerfileDefinition_0_3 `json:"dockerfile,omitempty"`
 	Go         *GoDefinition_0_3         `json:"go,omitempty"`
-	Image      *ImageDefinition_0_3      `json:"image,omitempty"`
+	Image      *ImageDefinition_0_3      `json:"docker,omitempty"`
 	Node       *NodeDefinition_0_3       `json:"node,omitempty"`
 	Python     *PythonDefinition_0_3     `json:"python,omitempty"`
 	Shell      *ShellDefinition_0_3      `json:"shell,omitempty"`

--- a/pkg/deploy/taskdir/definitions/def_0_3_test.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3_test.go
@@ -274,7 +274,7 @@ func TestTaskToDefinition_0_3(t *testing.T) {
 				Name:        "Image Task",
 				Slug:        "image_task",
 				Command:     []string{"bash"},
-				Arguments:   []string{"-c", "echo 'foobar'"},
+				Arguments:   []string{"-c", `echo "foobar"`},
 				Kind:        build.TaskKindImage,
 				KindOptions: build.KindOptions{},
 				Image:       newStringPtr("ubuntu:latest"),
@@ -285,7 +285,7 @@ func TestTaskToDefinition_0_3(t *testing.T) {
 				Image: &ImageDefinition_0_3{
 					Image:      "ubuntu:latest",
 					Entrypoint: "bash",
-					Command:    []string{"-c", "echo 'foobar'"},
+					Command:    `-c 'echo "foobar"'`,
 				},
 			},
 		},
@@ -605,7 +605,7 @@ func TestDefinitionToUpdateTaskRequest_0_3(t *testing.T) {
 				Image: &ImageDefinition_0_3{
 					Image:      "ubuntu:latest",
 					Entrypoint: "bash",
-					Command:    []string{"-c", "echo 'foobar'"},
+					Command:    `-c 'echo "foobar"'`,
 				},
 			},
 			request: api.UpdateTaskRequest{
@@ -613,7 +613,7 @@ func TestDefinitionToUpdateTaskRequest_0_3(t *testing.T) {
 				Slug:       "image_task",
 				Parameters: []api.Parameter{},
 				Command:    []string{"bash"},
-				Arguments:  []string{"-c", "echo 'foobar'"},
+				Arguments:  []string{"-c", `echo "foobar"`},
 				Kind:       build.TaskKindImage,
 				Image:      newStringPtr("ubuntu:latest"),
 			},

--- a/pkg/deploy/taskdir/definitions/schema_0_3.json
+++ b/pkg/deploy/taskdir/definitions/schema_0_3.json
@@ -69,7 +69,7 @@
         {
           "type": "object",
           "properties": {
-            "image": {
+            "docker": {
               "type": "object",
               "properties": {
                 "image": { "type": "string" },
@@ -81,7 +81,7 @@
               "required": ["image"]
             }
           },
-          "required": ["image"]
+          "required": ["docker"]
         }
       ]
     },
@@ -229,8 +229,8 @@
     "node": true,
     "python": true,
     "shell": true,
-    "image": true,
     "deno": true,
+    "docker": true,
     "go": true,
     "dockerfile": true,
     "sql": true,

--- a/pkg/deploy/taskdir/definitions/schema_0_3.json
+++ b/pkg/deploy/taskdir/definitions/schema_0_3.json
@@ -73,7 +73,7 @@
               "type": "object",
               "properties": {
                 "image": { "type": "string" },
-                "command": { "type": "array", "items": { "type": "string" } },
+                "command": { "type": "string" },
                 "entrypoint": { "type": "string" },
                 "envVars": { "$ref": "#/$defs/envVars" }
               },

--- a/pkg/deploy/taskdir/definitions/schema_0_3.json
+++ b/pkg/deploy/taskdir/definitions/schema_0_3.json
@@ -335,20 +335,9 @@
         },
         "constraints": {
           "type": "object",
-          "properties": {
-            "labels": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "key": { "type": "string" },
-                  "value": { "type": "string" }
-                },
-                "additionalProperties": false
-              }
-            }
-          },
-          "additionalProperties": false
+          "patternProperties": {
+            ".*": { "type": "string" }
+          }
         },
         "requireRequests": { "type": "boolean" },
         "allowSelfApprovals": { "type": "boolean" },


### PR DESCRIPTION
Some schema refactoring, in an effort to get the schema closer to what's on the frontend.

* Renames `image` to `docker`. (Internally we still refer to this as kind=image, so it remains ImageDefinition.)
* Moves Docker command to a string instead of a string array.
* Simplifies constraints to be a map of key -> label.