### PR TITLE
Switch to python 3.9.6 bullseye

### DIFF
--- a/pkg/build/versions.json
+++ b/pkg/build/versions.json
@@ -38,8 +38,8 @@
   "python": {
     "3": {
       "image": "registry.hub.docker.com/library/python",
-      "tag": "3.9.4-buster",
-      "digest": "sha256:b004a71e38f8ace26e7554d5c2fa802a8bb39a5818cbe10ab49fd0b408a40c20"
+      "tag": "3.9.6-bullseye",
+      "digest": "sha256-ddd039d4d5462c862ec1c715f78102f5a2db7ae1fda672a90941b92e766c7746"
     }
   }
 }

--- a/pkg/build/versions.json
+++ b/pkg/build/versions.json
@@ -39,7 +39,7 @@
     "3": {
       "image": "registry.hub.docker.com/library/python",
       "tag": "3.9.6-bullseye",
-      "digest": "sha256-ddd039d4d5462c862ec1c715f78102f5a2db7ae1fda672a90941b92e766c7746"
+      "digest": "sha256:736b76eb3f64778646ce0051fb5fed4dfbf67016e51563946230ca8bb40ac687"
     }
   }
 }


### PR DESCRIPTION
Upgrade python from buster -> (more up to date) bullseye. Use the closest version of python 3.9.4 -> 3.9.6.

This image has OpenSSL 1.1.1k  25 Mar 2021 instead of a 2019 version. 

FIXES AIR-2903

---

We determined that openssl is probably not causing any issues, but this upgrades us to a newer version.

We're skipping from d->k https://www.openssl.org/news/openssl-1.1.1-notes.html

