### PR TITLE
Handle parameters with config var options

### DIFF
--- a/pkg/deploy/taskdir/definitions/def_0_3_test.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3_test.go
@@ -506,6 +506,13 @@ func TestTaskToDefinition_0_3(t *testing.T) {
 									Label: "three",
 									Value: 3,
 								},
+								{
+									Label: "config",
+									Value: map[string]interface{}{
+										"__airplaneType": "configvar",
+										"name":           "config_name",
+									},
+								},
 							},
 						},
 					},
@@ -567,6 +574,10 @@ func TestTaskToDefinition_0_3(t *testing.T) {
 							{
 								Label: "three",
 								Value: 3,
+							},
+							{
+								Label:  "config",
+								Config: pointers.String("config_name"),
 							},
 						},
 					},
@@ -838,6 +849,147 @@ func TestDefinitionToUpdateTaskRequest_0_3(t *testing.T) {
 				Parameters:  []api.Parameter{},
 				Description: "A task for testing",
 				Kind:        build.TaskKindPython,
+				KindOptions: build.KindOptions{
+					"entrypoint": "main.py",
+				},
+				ExecuteRules: api.UpdateExecuteRulesRequest{
+					DisallowSelfApprove: pointers.Bool(false),
+					RequireRequests:     pointers.Bool(false),
+				},
+			},
+		},
+		{
+			name: "check parameters",
+			definition: Definition_0_3{
+				Name: "Test Task",
+				Slug: "test_task",
+				Parameters: []ParameterDefinition_0_3{
+					{
+						Name:        "Required boolean",
+						Slug:        "required_boolean",
+						Type:        "boolean",
+						Description: "A required boolean.",
+					},
+					{
+						Name:    "Short text",
+						Slug:    "short_text",
+						Type:    "shorttext",
+						Default: "foobar",
+					},
+					{
+						Name: "SQL",
+						Slug: "sql",
+						Type: "sql",
+					},
+					{
+						Name:     "Optional long text",
+						Slug:     "optional_long_text",
+						Type:     "longtext",
+						Required: pointers.Bool(false),
+					},
+					{
+						Name: "Options",
+						Slug: "options",
+						Type: "shorttext",
+						Options: []OptionDefinition_0_3{
+							{
+								Label: "one",
+								Value: 1,
+							},
+							{
+								Label: "two",
+								Value: 2,
+							},
+							{
+								Label: "three",
+								Value: 3,
+							},
+							{
+								Label:  "config",
+								Config: pointers.String("config_name"),
+							},
+						},
+					},
+					{
+						Name:  "Regex",
+						Slug:  "regex",
+						Type:  "shorttext",
+						Regex: "foo.*",
+					},
+				},
+				Python: &PythonDefinition_0_3{
+					Entrypoint: "main.py",
+				},
+			},
+			request: api.UpdateTaskRequest{
+				Name: "Test Task",
+				Slug: "test_task",
+				Parameters: []api.Parameter{
+					{
+						Name: "Required boolean",
+						Slug: "required_boolean",
+						Type: api.TypeBoolean,
+						Desc: "A required boolean.",
+					},
+					{
+						Name:    "Short text",
+						Slug:    "short_text",
+						Type:    api.TypeString,
+						Default: "foobar",
+					},
+					{
+						Name:      "SQL",
+						Slug:      "sql",
+						Type:      api.TypeString,
+						Component: api.ComponentEditorSQL,
+					},
+					{
+						Name:      "Optional long text",
+						Slug:      "optional_long_text",
+						Type:      api.TypeString,
+						Component: api.ComponentTextarea,
+						Constraints: api.Constraints{
+							Optional: true,
+						},
+					},
+					{
+						Name: "Options",
+						Slug: "options",
+						Type: api.TypeString,
+						Constraints: api.Constraints{
+							Options: []api.ConstraintOption{
+								{
+									Label: "one",
+									Value: 1,
+								},
+								{
+									Label: "two",
+									Value: 2,
+								},
+								{
+									Label: "three",
+									Value: 3,
+								},
+								{
+									Label: "config",
+									Value: map[string]interface{}{
+										"__airplaneType": "configvar",
+										"name":           "config_name",
+									},
+								},
+							},
+						},
+					},
+					{
+						Name: "Regex",
+						Slug: "regex",
+						Type: api.TypeString,
+						Constraints: api.Constraints{
+							Regex: "foo.*",
+						},
+					},
+				},
+				Kind: build.TaskKindPython,
 				KindOptions: build.KindOptions{
 					"entrypoint": "main.py",
 				},

--- a/pkg/deploy/taskdir/definitions/fixtures/docker.task.yaml
+++ b/pkg/deploy/taskdir/definitions/fixtures/docker.task.yaml
@@ -24,10 +24,14 @@ name: My Task
 #   default: Alfred Pennyworth
 #   # Set to false to indicate that this parameter. is optional. Default: true.
 #   required: false
-#   # A list of options to constrain the parameter values.
+#   # A list of options to constrain the parameter values. For configvar types,
+#   # each option needs to be an object with a label (value to show to user) and
+#   # a config (name of the config var). For all other types, each option can be
+#   # a single value or an object with a label and a value.
 #   options:
 #   - Alfred Pennyworth
-#   - Bruce Wayne
+#   - label: Batman
+#     value: Bruce Wayne
 #   # A regular expression with which to validate parameter values.
 #   regex: "^[a-zA-Z ]+$"
 

--- a/pkg/deploy/taskdir/definitions/fixtures/node.task.yaml
+++ b/pkg/deploy/taskdir/definitions/fixtures/node.task.yaml
@@ -24,10 +24,14 @@ name: My Task
 #   default: Alfred Pennyworth
 #   # Set to false to indicate that this parameter. is optional. Default: true.
 #   required: false
-#   # A list of options to constrain the parameter values.
+#   # A list of options to constrain the parameter values. For configvar types,
+#   # each option needs to be an object with a label (value to show to user) and
+#   # a config (name of the config var). For all other types, each option can be
+#   # a single value or an object with a label and a value.
 #   options:
 #   - Alfred Pennyworth
-#   - Bruce Wayne
+#   - label: Batman
+#     value: Bruce Wayne
 #   # A regular expression with which to validate parameter values.
 #   regex: "^[a-zA-Z ]+$"
 

--- a/pkg/deploy/taskdir/definitions/fixtures/python.task.yaml
+++ b/pkg/deploy/taskdir/definitions/fixtures/python.task.yaml
@@ -24,10 +24,14 @@ name: My Task
 #   default: Alfred Pennyworth
 #   # Set to false to indicate that this parameter. is optional. Default: true.
 #   required: false
-#   # A list of options to constrain the parameter values.
+#   # A list of options to constrain the parameter values. For configvar types,
+#   # each option needs to be an object with a label (value to show to user) and
+#   # a config (name of the config var). For all other types, each option can be
+#   # a single value or an object with a label and a value.
 #   options:
 #   - Alfred Pennyworth
-#   - Bruce Wayne
+#   - label: Batman
+#     value: Bruce Wayne
 #   # A regular expression with which to validate parameter values.
 #   regex: "^[a-zA-Z ]+$"
 

--- a/pkg/deploy/taskdir/definitions/fixtures/rest.task.yaml
+++ b/pkg/deploy/taskdir/definitions/fixtures/rest.task.yaml
@@ -24,10 +24,14 @@ name: My Task
 #   default: Alfred Pennyworth
 #   # Set to false to indicate that this parameter. is optional. Default: true.
 #   required: false
-#   # A list of options to constrain the parameter values.
+#   # A list of options to constrain the parameter values. For configvar types,
+#   # each option needs to be an object with a label (value to show to user) and
+#   # a config (name of the config var). For all other types, each option can be
+#   # a single value or an object with a label and a value.
 #   options:
 #   - Alfred Pennyworth
-#   - Bruce Wayne
+#   - label: Batman
+#     value: Bruce Wayne
 #   # A regular expression with which to validate parameter values.
 #   regex: "^[a-zA-Z ]+$"
 

--- a/pkg/deploy/taskdir/definitions/fixtures/shell.task.yaml
+++ b/pkg/deploy/taskdir/definitions/fixtures/shell.task.yaml
@@ -24,10 +24,14 @@ name: My Task
 #   default: Alfred Pennyworth
 #   # Set to false to indicate that this parameter. is optional. Default: true.
 #   required: false
-#   # A list of options to constrain the parameter values.
+#   # A list of options to constrain the parameter values. For configvar types,
+#   # each option needs to be an object with a label (value to show to user) and
+#   # a config (name of the config var). For all other types, each option can be
+#   # a single value or an object with a label and a value.
 #   options:
 #   - Alfred Pennyworth
-#   - Bruce Wayne
+#   - label: Batman
+#     value: Bruce Wayne
 #   # A regular expression with which to validate parameter values.
 #   regex: "^[a-zA-Z ]+$"
 

--- a/pkg/deploy/taskdir/definitions/fixtures/sql.task.yaml
+++ b/pkg/deploy/taskdir/definitions/fixtures/sql.task.yaml
@@ -24,10 +24,14 @@ name: My Task
 #   default: Alfred Pennyworth
 #   # Set to false to indicate that this parameter. is optional. Default: true.
 #   required: false
-#   # A list of options to constrain the parameter values.
+#   # A list of options to constrain the parameter values. For configvar types,
+#   # each option needs to be an object with a label (value to show to user) and
+#   # a config (name of the config var). For all other types, each option can be
+#   # a single value or an object with a label and a value.
 #   options:
 #   - Alfred Pennyworth
-#   - Bruce Wayne
+#   - label: Batman
+#     value: Bruce Wayne
 #   # A regular expression with which to validate parameter values.
 #   regex: "^[a-zA-Z ]+$"
 

--- a/pkg/deploy/taskdir/definitions/schema_0_3.json
+++ b/pkg/deploy/taskdir/definitions/schema_0_3.json
@@ -341,7 +341,7 @@
           "type": "boolean"
         },
         "options": {
-          "description": "A list of options to constrain the parameter values. Can be a single value, an object with a label and a value, or an object with a label and a config var.",
+          "description": "A list of options to constrain the parameter values. For configvar types, each option needs to be an object with a label (value to show to user) and a config (name of the config var). For all other types, each option can be a single value or an object with a label and a value.",
           "type": "array",
           "items": {
             "anyOf": [

--- a/pkg/deploy/taskdir/definitions/schema_0_3.json
+++ b/pkg/deploy/taskdir/definitions/schema_0_3.json
@@ -341,7 +341,7 @@
           "type": "boolean"
         },
         "options": {
-          "description": "A list of options to constrain the parameter values.",
+          "description": "A list of options to constrain the parameter values. Can be a single value, an object with a label and a value, or an object with a label and a config var.",
           "type": "array",
           "items": {
             "anyOf": [
@@ -360,6 +360,16 @@
                     ]
                   }
                 },
+                "required": ["label", "value"],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "label": { "type": "string" },
+                  "config": { "type": "string" }
+                },
+                "required": ["label", "config"],
                 "additionalProperties": false
               }
             ]

--- a/pkg/deploy/taskdir/definitions/schema_0_3.json
+++ b/pkg/deploy/taskdir/definitions/schema_0_3.json
@@ -342,6 +342,10 @@
         },
         "options": {
           "description": "A list of options to constrain the parameter values. For configvar types, each option needs to be an object with a label (value to show to user) and a config (name of the config var). For all other types, each option can be a single value or an object with a label and a value.",
+          "examples": [
+            "Alfred Pennyworth",
+            { "label": "Batman", "value": "Bruce Wayne" }
+          ],
           "type": "array",
           "items": {
             "anyOf": [

--- a/pkg/deploy/taskdir/definitions/yaml_templates.go
+++ b/pkg/deploy/taskdir/definitions/yaml_templates.go
@@ -26,10 +26,14 @@ name: {{.name}}
 #   default: Alfred Pennyworth
 #   # Set to false to indicate that this parameter. is optional. Default: true.
 #   required: false
-#   # A list of options to constrain the parameter values.
+#   # A list of options to constrain the parameter values. For configvar types,
+#   # each option needs to be an object with a label (value to show to user) and
+#   # a config (name of the config var). For all other types, each option can be
+#   # a single value or an object with a label and a value.
 #   options:
 #   - Alfred Pennyworth
-#   - Bruce Wayne
+#   - label: Batman
+#     value: Bruce Wayne
 #   # A regular expression with which to validate parameter values.
 #   regex: "^[a-zA-Z ]+$"
 {{ .taskDefinition }}


### PR DESCRIPTION
## Description

Updates schema + parameter handling for config var options. Resolves AIR-3351.

## Test plan

Run `airplane init` from a task with a parameter with config var options. Run `airplane deploy` on resulting definition file.

