### PR TITLE
Add TransactionMode to SQL tasks

### DIFF
--- a/pkg/deploy/taskdir/definitions/def_0_3.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3.go
@@ -797,7 +797,8 @@ func NewDefinition_0_3(name string, slug string, kind build.TaskKind, entrypoint
 		}
 	case build.TaskKindSQL:
 		def.SQL = &SQLDefinition_0_3{
-			Entrypoint: entrypoint,
+			Entrypoint:      entrypoint,
+			TransactionMode: "auto",
 		}
 	case build.TaskKindREST:
 		def.REST = &RESTDefinition_0_3{

--- a/pkg/deploy/taskdir/definitions/def_0_3.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3.go
@@ -576,6 +576,8 @@ func (d *SQLDefinition_0_3) getKindOptions() (build.KindOptions, error) {
 	}
 	if d.TransactionMode != "" {
 		options["transactionMode"] = d.TransactionMode
+	} else {
+		options["transactionMode"] = "auto"
 	}
 	return options, nil
 }

--- a/pkg/deploy/taskdir/definitions/fixtures/sql.task.yaml
+++ b/pkg/deploy/taskdir/definitions/fixtures/sql.task.yaml
@@ -54,7 +54,7 @@ sql:
 
   # The transaction mode to use. Valid values: auto, readOnly, readWrite, none.
   # Default: auto.
-  transactionMode: auto
+  # transactionMode: readWrite
 
 # Set label constraints to restrict this task to run only on agents with
 # matching labels.

--- a/pkg/deploy/taskdir/definitions/fixtures/sql.task.yaml
+++ b/pkg/deploy/taskdir/definitions/fixtures/sql.task.yaml
@@ -52,6 +52,10 @@ sql:
   # queryArgs:
   #   name: "{{params.name}}"
 
+  # The transaction mode to use. Valid values: auto, readOnly, readWrite, none.
+  # Default: auto.
+  transactionMode: auto
+
 # Set label constraints to restrict this task to run only on agents with
 # matching labels.
 # constraints:

--- a/pkg/deploy/taskdir/definitions/schema_0_3.json
+++ b/pkg/deploy/taskdir/definitions/schema_0_3.json
@@ -201,6 +201,11 @@
                   "patternProperties": {
                     ".*": { "type": ["string", "boolean", "number"] }
                   }
+                },
+                "transactionMode": {
+                  "description": "The transaction mode to use.",
+                  "default": "auto",
+                  "enum": ["auto", "readOnly", "readWrite", "none"]
                 }
               },
               "additionalProperties": false,

--- a/pkg/deploy/taskdir/definitions/yaml_templates.go
+++ b/pkg/deploy/taskdir/definitions/yaml_templates.go
@@ -156,6 +156,10 @@ sql:
   # (https://docs.airplane.dev/runbooks/javascript-templates).
   # queryArgs:
   #   name: "{{"{{params.name}}"}}"
+
+  # The transaction mode to use. Valid values: auto, readOnly, readWrite, none.
+  # Default: auto.
+  transactionMode: {{.TransactionMode}}
 `
 
 const restTemplate = `

--- a/pkg/deploy/taskdir/definitions/yaml_templates.go
+++ b/pkg/deploy/taskdir/definitions/yaml_templates.go
@@ -159,7 +159,7 @@ sql:
 
   # The transaction mode to use. Valid values: auto, readOnly, readWrite, none.
   # Default: auto.
-  transactionMode: {{.TransactionMode}}
+  # transactionMode: readWrite
 `
 
 const restTemplate = `


### PR DESCRIPTION
## Description

New SQL tasks get created with a default TransactionMode of auto. Initializing SQL tasks without a TransactionMode results in no transactionMode entry in the definition file. Resolves AIR-2896.

## Test plan

Deploy a SQL task with a transaction mode. Initialize a SQL task from an existing task with a transaction mode, and without a transaction mode.