### PR TITLE
Err if entrypoint does not exist

### DIFF
--- a/pkg/deploy/discover/defn_discover.go
+++ b/pkg/deploy/discover/defn_discover.go
@@ -8,6 +8,7 @@ import (
 	"github.com/airplanedev/lib/pkg/deploy/taskdir"
 	"github.com/airplanedev/lib/pkg/deploy/taskdir/definitions"
 	"github.com/airplanedev/lib/pkg/runtime"
+	"github.com/airplanedev/lib/pkg/utils/fsx"
 	"github.com/airplanedev/lib/pkg/utils/logger"
 	"github.com/pkg/errors"
 )
@@ -93,6 +94,8 @@ func (dd *DefnDiscoverer) GetTaskConfig(ctx context.Context, file string) (*Task
 	if err == definitions.ErrNoEntrypoint {
 		return &tc, nil
 	} else if err != nil {
+		return nil, err
+	} else if err = fsx.AssertExistsAll(entrypoint); err != nil {
 		return nil, err
 	} else {
 		tc.TaskEntrypoint = entrypoint

--- a/pkg/deploy/discover/discover_test.go
+++ b/pkg/deploy/discover/discover_test.go
@@ -257,6 +257,14 @@ func TestDiscoverTasks(t *testing.T) {
 				fixturesPath + "/subdir/single_task.js",
 			},
 		},
+		{
+			name:  "defn - entrypoint does not exist",
+			paths: []string{"./fixtures/defn_incorrect_entrypoint.task.yaml"},
+			existingTasks: map[string]api.Task{
+				"incorrect_entrypoint": {ID: "tsk123", Slug: "incorrect_entrypoint", Kind: build.TaskKindNode, InterpolationMode: "jst"},
+			},
+			expectedErr: true,
+		},
 	}
 	for _, tC := range tests {
 		t.Run(tC.name, func(t *testing.T) {

--- a/pkg/deploy/discover/fixtures/defn.task.yaml
+++ b/pkg/deploy/discover/fixtures/defn.task.yaml
@@ -2,5 +2,5 @@ name: sunt in tempor eu
 slug: my_task
 node:
   entrypoint: ./single_task.js
-  nodeVersion: '14'
+  nodeVersion: "14"
 description: ut dolor sit officia ea

--- a/pkg/deploy/discover/fixtures/defn_incorrect_entrypoint.task.yaml
+++ b/pkg/deploy/discover/fixtures/defn_incorrect_entrypoint.task.yaml
@@ -1,0 +1,6 @@
+name: sunt in tempor eu
+slug: incorrect_entrypoint
+node:
+  entrypoint: ./incorrect_entrypoint.js
+  nodeVersion: '14'
+description: ut dolor sit officia ea


### PR DESCRIPTION
## Description
Throw an error in the discovery phase if the entrypoint does not exist. Current behavior is that the deploy fails and we throw a sentry error.

Ideally we'd also not log a sentry err if one of these sneaks in. We can implement this too, but it requires integrating the error lib into lib.

## Test plan
Unit tested
