### PR TITLE
Add configs to task definition yaml

### DIFF
--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -20,28 +20,28 @@ type IAPIClient interface {
 
 // Task represents a task.
 type Task struct {
-	URL                        string             `json:"-" yaml:"-"`
-	ID                         string             `json:"taskID" yaml:"id"`
-	Name                       string             `json:"name" yaml:"name"`
-	Slug                       string             `json:"slug" yaml:"slug"`
-	Description                string             `json:"description" yaml:"description"`
-	Image                      *string            `json:"image" yaml:"image"`
-	Command                    []string           `json:"command" yaml:"command"`
-	Arguments                  []string           `json:"arguments" yaml:"arguments"`
-	Parameters                 Parameters         `json:"parameters" yaml:"parameters"`
-	Configs                    []ConfigAttachment `json:"configs" yaml:"configs"`
-	Constraints                RunConstraints     `json:"constraints" yaml:"constraints"`
-	Env                        TaskEnv            `json:"env" yaml:"env"`
-	ResourceRequests           ResourceRequests   `json:"resourceRequests" yaml:"resourceRequests"`
-	Resources                  Resources          `json:"resources" yaml:"resources"`
-	Kind                       build.TaskKind     `json:"kind" yaml:"kind"`
-	KindOptions                build.KindOptions  `json:"kindOptions" yaml:"kindOptions"`
-	Repo                       string             `json:"repo" yaml:"repo"`
-	RequireExplicitPermissions bool               `json:"requireExplicitPermissions" yaml:"-"`
-	Permissions                Permissions        `json:"permissions" yaml:"-"`
-	ExecuteRules               ExecuteRules       `json:"executeRules" yaml:"-"`
-	Timeout                    int                `json:"timeout" yaml:"timeout"`
-	InterpolationMode          string             `json:"interpolationMode" yaml:"-"`
+	URL                        string              `json:"-" yaml:"-"`
+	ID                         string              `json:"taskID" yaml:"id"`
+	Name                       string              `json:"name" yaml:"name"`
+	Slug                       string              `json:"slug" yaml:"slug"`
+	Description                string              `json:"description" yaml:"description"`
+	Image                      *string             `json:"image" yaml:"image"`
+	Command                    []string            `json:"command" yaml:"command"`
+	Arguments                  []string            `json:"arguments" yaml:"arguments"`
+	Parameters                 Parameters          `json:"parameters" yaml:"parameters"`
+	Configs                    *[]ConfigAttachment `json:"configs" yaml:"configs"`
+	Constraints                RunConstraints      `json:"constraints" yaml:"constraints"`
+	Env                        TaskEnv             `json:"env" yaml:"env"`
+	ResourceRequests           ResourceRequests    `json:"resourceRequests" yaml:"resourceRequests"`
+	Resources                  Resources           `json:"resources" yaml:"resources"`
+	Kind                       build.TaskKind      `json:"kind" yaml:"kind"`
+	KindOptions                build.KindOptions   `json:"kindOptions" yaml:"kindOptions"`
+	Repo                       string              `json:"repo" yaml:"repo"`
+	RequireExplicitPermissions bool                `json:"requireExplicitPermissions" yaml:"-"`
+	Permissions                Permissions         `json:"permissions" yaml:"-"`
+	ExecuteRules               ExecuteRules        `json:"executeRules" yaml:"-"`
+	Timeout                    int                 `json:"timeout" yaml:"timeout"`
+	InterpolationMode          string              `json:"interpolationMode" yaml:"-"`
 }
 
 type GetTaskRequest struct {
@@ -77,7 +77,7 @@ type UpdateTaskRequest struct {
 	Command                    []string                  `json:"command"`
 	Arguments                  []string                  `json:"arguments"`
 	Parameters                 Parameters                `json:"parameters"`
-	Configs                    []ConfigAttachment        `json:"configs"`
+	Configs                    *[]ConfigAttachment       `json:"configs"`
 	Constraints                RunConstraints            `json:"constraints"`
 	Env                        TaskEnv                   `json:"env"`
 	ResourceRequests           map[string]string         `json:"resourceRequests"`

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -20,28 +20,28 @@ type IAPIClient interface {
 
 // Task represents a task.
 type Task struct {
-	URL                        string              `json:"-" yaml:"-"`
-	ID                         string              `json:"taskID" yaml:"id"`
-	Name                       string              `json:"name" yaml:"name"`
-	Slug                       string              `json:"slug" yaml:"slug"`
-	Description                string              `json:"description" yaml:"description"`
-	Image                      *string             `json:"image" yaml:"image"`
-	Command                    []string            `json:"command" yaml:"command"`
-	Arguments                  []string            `json:"arguments" yaml:"arguments"`
-	Parameters                 Parameters          `json:"parameters" yaml:"parameters"`
-	Configs                    *[]ConfigAttachment `json:"configs" yaml:"configs"`
-	Constraints                RunConstraints      `json:"constraints" yaml:"constraints"`
-	Env                        TaskEnv             `json:"env" yaml:"env"`
-	ResourceRequests           ResourceRequests    `json:"resourceRequests" yaml:"resourceRequests"`
-	Resources                  Resources           `json:"resources" yaml:"resources"`
-	Kind                       build.TaskKind      `json:"kind" yaml:"kind"`
-	KindOptions                build.KindOptions   `json:"kindOptions" yaml:"kindOptions"`
-	Repo                       string              `json:"repo" yaml:"repo"`
-	RequireExplicitPermissions bool                `json:"requireExplicitPermissions" yaml:"-"`
-	Permissions                Permissions         `json:"permissions" yaml:"-"`
-	ExecuteRules               ExecuteRules        `json:"executeRules" yaml:"-"`
-	Timeout                    int                 `json:"timeout" yaml:"timeout"`
-	InterpolationMode          string              `json:"interpolationMode" yaml:"-"`
+	URL                        string             `json:"-" yaml:"-"`
+	ID                         string             `json:"taskID" yaml:"id"`
+	Name                       string             `json:"name" yaml:"name"`
+	Slug                       string             `json:"slug" yaml:"slug"`
+	Description                string             `json:"description" yaml:"description"`
+	Image                      *string            `json:"image" yaml:"image"`
+	Command                    []string           `json:"command" yaml:"command"`
+	Arguments                  []string           `json:"arguments" yaml:"arguments"`
+	Parameters                 Parameters         `json:"parameters" yaml:"parameters"`
+	Configs                    []ConfigAttachment `json:"configs" yaml:"configs"`
+	Constraints                RunConstraints     `json:"constraints" yaml:"constraints"`
+	Env                        TaskEnv            `json:"env" yaml:"env"`
+	ResourceRequests           ResourceRequests   `json:"resourceRequests" yaml:"resourceRequests"`
+	Resources                  Resources          `json:"resources" yaml:"resources"`
+	Kind                       build.TaskKind     `json:"kind" yaml:"kind"`
+	KindOptions                build.KindOptions  `json:"kindOptions" yaml:"kindOptions"`
+	Repo                       string             `json:"repo" yaml:"repo"`
+	RequireExplicitPermissions bool               `json:"requireExplicitPermissions" yaml:"-"`
+	Permissions                Permissions        `json:"permissions" yaml:"-"`
+	ExecuteRules               ExecuteRules       `json:"executeRules" yaml:"-"`
+	Timeout                    int                `json:"timeout" yaml:"timeout"`
+	InterpolationMode          string             `json:"interpolationMode" yaml:"-"`
 }
 
 type GetTaskRequest struct {

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -20,27 +20,28 @@ type IAPIClient interface {
 
 // Task represents a task.
 type Task struct {
-	URL                        string            `json:"-" yaml:"-"`
-	ID                         string            `json:"taskID" yaml:"id"`
-	Name                       string            `json:"name" yaml:"name"`
-	Slug                       string            `json:"slug" yaml:"slug"`
-	Description                string            `json:"description" yaml:"description"`
-	Image                      *string           `json:"image" yaml:"image"`
-	Command                    []string          `json:"command" yaml:"command"`
-	Arguments                  []string          `json:"arguments" yaml:"arguments"`
-	Parameters                 Parameters        `json:"parameters" yaml:"parameters"`
-	Constraints                RunConstraints    `json:"constraints" yaml:"constraints"`
-	Env                        TaskEnv           `json:"env" yaml:"env"`
-	ResourceRequests           ResourceRequests  `json:"resourceRequests" yaml:"resourceRequests"`
-	Resources                  Resources         `json:"resources" yaml:"resources"`
-	Kind                       build.TaskKind    `json:"kind" yaml:"kind"`
-	KindOptions                build.KindOptions `json:"kindOptions" yaml:"kindOptions"`
-	Repo                       string            `json:"repo" yaml:"repo"`
-	RequireExplicitPermissions bool              `json:"requireExplicitPermissions" yaml:"-"`
-	Permissions                Permissions       `json:"permissions" yaml:"-"`
-	ExecuteRules               ExecuteRules      `json:"executeRules" yaml:"-"`
-	Timeout                    int               `json:"timeout" yaml:"timeout"`
-	InterpolationMode          string            `json:"interpolationMode" yaml:"-"`
+	URL                        string             `json:"-" yaml:"-"`
+	ID                         string             `json:"taskID" yaml:"id"`
+	Name                       string             `json:"name" yaml:"name"`
+	Slug                       string             `json:"slug" yaml:"slug"`
+	Description                string             `json:"description" yaml:"description"`
+	Image                      *string            `json:"image" yaml:"image"`
+	Command                    []string           `json:"command" yaml:"command"`
+	Arguments                  []string           `json:"arguments" yaml:"arguments"`
+	Parameters                 Parameters         `json:"parameters" yaml:"parameters"`
+	Configs                    []ConfigAttachment `json:"configs" yaml:"configs"`
+	Constraints                RunConstraints     `json:"constraints" yaml:"constraints"`
+	Env                        TaskEnv            `json:"env" yaml:"env"`
+	ResourceRequests           ResourceRequests   `json:"resourceRequests" yaml:"resourceRequests"`
+	Resources                  Resources          `json:"resources" yaml:"resources"`
+	Kind                       build.TaskKind     `json:"kind" yaml:"kind"`
+	KindOptions                build.KindOptions  `json:"kindOptions" yaml:"kindOptions"`
+	Repo                       string             `json:"repo" yaml:"repo"`
+	RequireExplicitPermissions bool               `json:"requireExplicitPermissions" yaml:"-"`
+	Permissions                Permissions        `json:"permissions" yaml:"-"`
+	ExecuteRules               ExecuteRules       `json:"executeRules" yaml:"-"`
+	Timeout                    int                `json:"timeout" yaml:"timeout"`
+	InterpolationMode          string             `json:"interpolationMode" yaml:"-"`
 }
 
 type GetTaskRequest struct {
@@ -76,6 +77,7 @@ type UpdateTaskRequest struct {
 	Command                    []string                  `json:"command"`
 	Arguments                  []string                  `json:"arguments"`
 	Parameters                 Parameters                `json:"parameters"`
+	Configs                    []ConfigAttachment        `json:"configs"`
 	Constraints                RunConstraints            `json:"constraints"`
 	Env                        TaskEnv                   `json:"env"`
 	ResourceRequests           map[string]string         `json:"resourceRequests"`
@@ -241,8 +243,10 @@ type Parameter struct {
 	Constraints Constraints `json:"constraints" yaml:"constraints,omitempty"`
 }
 
-// TODO(amir): remove custom marshal/unmarshal once the API is updated.
-// type Parameters []Parameter
+// ConfigAttachment represents a config attachment.
+type ConfigAttachment struct {
+	NameTag string `json:"nameTag" yaml:"nameTag"`
+}
 
 // UnmarshalJSON implementation.
 func (p *Parameters) UnmarshalJSON(buf []byte) error {

--- a/pkg/deploy/taskdir/definitions/def_0_3.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3.go
@@ -565,11 +565,9 @@ func (d *SQLDefinition_0_3) hydrateFromTask(ctx context.Context, client api.IAPI
 		}
 	}
 
-	if t.Configs != nil {
-		d.Configs = make([]string, len(*t.Configs))
-		for idx, config := range *t.Configs {
-			d.Configs[idx] = config.NameTag
-		}
+	d.Configs = make([]string, len(t.Configs))
+	for idx, config := range t.Configs {
+		d.Configs[idx] = config.NameTag
 	}
 
 	return nil
@@ -708,11 +706,9 @@ func (d *RESTDefinition_0_3) hydrateFromTask(ctx context.Context, client api.IAP
 		}
 	}
 
-	if t.Configs != nil {
-		d.Configs = make([]string, len(*t.Configs))
-		for idx, config := range *t.Configs {
-			d.Configs[idx] = config.NameTag
-		}
+	d.Configs = make([]string, len(t.Configs))
+	for idx, config := range t.Configs {
+		d.Configs[idx] = config.NameTag
 	}
 
 	return nil

--- a/pkg/deploy/taskdir/definitions/def_0_3.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3.go
@@ -565,9 +565,11 @@ func (d *SQLDefinition_0_3) hydrateFromTask(ctx context.Context, client api.IAPI
 		}
 	}
 
-	d.Configs = make([]string, len(*t.Configs))
-	for idx, config := range *t.Configs {
-		d.Configs[idx] = config.NameTag
+	if t.Configs != nil {
+		d.Configs = make([]string, len(*t.Configs))
+		for idx, config := range *t.Configs {
+			d.Configs[idx] = config.NameTag
+		}
 	}
 
 	return nil
@@ -706,9 +708,11 @@ func (d *RESTDefinition_0_3) hydrateFromTask(ctx context.Context, client api.IAP
 		}
 	}
 
-	d.Configs = make([]string, len(*t.Configs))
-	for idx, config := range *t.Configs {
-		d.Configs[idx] = config.NameTag
+	if t.Configs != nil {
+		d.Configs = make([]string, len(*t.Configs))
+		for idx, config := range *t.Configs {
+			d.Configs[idx] = config.NameTag
+		}
 	}
 
 	return nil

--- a/pkg/deploy/taskdir/definitions/def_0_3.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3.go
@@ -897,7 +897,6 @@ func (d Definition_0_3) GenerateCommentedFile(format TaskDefFormat) ([]byte, err
 	}
 
 	taskDefinition := new(bytes.Buffer)
-	var configAttachments string
 	switch kind {
 	case build.TaskKindImage:
 		if d.Image.Entrypoint != "" || len(d.Image.EnvVars) > 0 {
@@ -978,10 +977,9 @@ func (d Definition_0_3) GenerateCommentedFile(format TaskDefFormat) ([]byte, err
 	}
 	buf := new(bytes.Buffer)
 	if err := tmpl.Execute(buf, map[string]interface{}{
-		"slug":              d.Slug,
-		"name":              d.Name,
-		"taskDefinition":    taskDefinition.String(),
-		"configAttachments": configAttachments,
+		"slug":           d.Slug,
+		"name":           d.Name,
+		"taskDefinition": taskDefinition.String(),
 	}); err != nil {
 		return nil, errors.Wrap(err, "executing definition template")
 	}

--- a/pkg/deploy/taskdir/definitions/def_0_3.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3.go
@@ -564,11 +564,9 @@ func (d *SQLDefinition_0_3) hydrateFromTask(ctx context.Context, client api.IAPI
 		}
 	}
 
-	if len(t.Configs) > 0 {
-		d.Configs = make([]string, len(t.Configs))
-		for idx, config := range t.Configs {
-			d.Configs[idx] = config.NameTag
-		}
+	d.Configs = make([]string, len(t.Configs))
+	for idx, config := range t.Configs {
+		d.Configs[idx] = config.NameTag
 	}
 
 	return nil
@@ -706,11 +704,9 @@ func (d *RESTDefinition_0_3) hydrateFromTask(ctx context.Context, client api.IAP
 		}
 	}
 
-	if len(t.Configs) > 0 {
-		d.Configs = make([]string, len(t.Configs))
-		for idx, config := range t.Configs {
-			d.Configs[idx] = config.NameTag
-		}
+	d.Configs = make([]string, len(t.Configs))
+	for idx, config := range t.Configs {
+		d.Configs[idx] = config.NameTag
 	}
 
 	return nil

--- a/pkg/deploy/taskdir/definitions/def_0_3.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3.go
@@ -516,12 +516,13 @@ func (d *SQLDefinition_0_3) fillInUpdateTaskRequest(ctx context.Context, client 
 	} else {
 		return errors.Errorf("unknown resource: %s", d.Resource)
 	}
-	req.Configs = make([]api.ConfigAttachment, len(d.Configs))
+	configs := make([]api.ConfigAttachment, len(d.Configs))
 	for i, configName := range d.Configs {
-		req.Configs[i] = api.ConfigAttachment{
+		configs[i] = api.ConfigAttachment{
 			NameTag: configName,
 		}
 	}
+	req.Configs = &configs
 	return nil
 }
 
@@ -564,8 +565,8 @@ func (d *SQLDefinition_0_3) hydrateFromTask(ctx context.Context, client api.IAPI
 		}
 	}
 
-	d.Configs = make([]string, len(t.Configs))
-	for idx, config := range t.Configs {
+	d.Configs = make([]string, len(*t.Configs))
+	for idx, config := range *t.Configs {
 		d.Configs[idx] = config.NameTag
 	}
 
@@ -639,12 +640,13 @@ func (d *RESTDefinition_0_3) fillInUpdateTaskRequest(ctx context.Context, client
 	} else {
 		return errors.Errorf("unknown resource: %s", d.Resource)
 	}
-	req.Configs = make([]api.ConfigAttachment, len(d.Configs))
+	configs := make([]api.ConfigAttachment, len(d.Configs))
 	for i, configName := range d.Configs {
-		req.Configs[i] = api.ConfigAttachment{
+		configs[i] = api.ConfigAttachment{
 			NameTag: configName,
 		}
 	}
+	req.Configs = &configs
 	return nil
 }
 
@@ -704,8 +706,8 @@ func (d *RESTDefinition_0_3) hydrateFromTask(ctx context.Context, client api.IAP
 		}
 	}
 
-	d.Configs = make([]string, len(t.Configs))
-	for idx, config := range t.Configs {
+	d.Configs = make([]string, len(*t.Configs))
+	for idx, config := range *t.Configs {
 		d.Configs[idx] = config.NameTag
 	}
 

--- a/pkg/deploy/taskdir/definitions/def_0_3_test.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3_test.go
@@ -16,7 +16,7 @@ var fullYAML = []byte(
 slug: hello_world
 description: A starter task.
 parameters:
-- name: NameTag
+- name: Name
   slug: name
   type: shorttext
   description: Someone's name.
@@ -34,7 +34,7 @@ var fullJSON = []byte(
 	"description": "A starter task.",
 	"parameters": [
 		{
-			"name": "NameTag",
+			"name": "Name",
 			"slug": "name",
 			"type": "shorttext",
 			"description": "Someone's name.",
@@ -53,7 +53,7 @@ var yamlWithDefault = []byte(
 slug: hello_world
 description: A starter task.
 parameters:
-- name: NameTag
+- name: Name
   slug: name
   type: shorttext
   description: Someone's name.
@@ -70,7 +70,7 @@ var jsonWithDefault = []byte(
 	"description": "A starter task.",
 	"parameters": [
 		{
-			"name": "NameTag",
+			"name": "Name",
 			"slug": "name",
 			"type": "shorttext",
 			"description": "Someone's name.",
@@ -89,7 +89,7 @@ var fullDef = Definition_0_3{
 	Description: "A starter task.",
 	Parameters: []ParameterDefinition_0_3{
 		{
-			Name:        "NameTag",
+			Name:        "Name",
 			Slug:        "name",
 			Type:        "shorttext",
 			Description: "Someone's name.",
@@ -109,7 +109,7 @@ var defWithDefault = Definition_0_3{
 	Description: "A starter task.",
 	Parameters: []ParameterDefinition_0_3{
 		{
-			Name:        "NameTag",
+			Name:        "Name",
 			Slug:        "name",
 			Type:        "shorttext",
 			Description: "Someone's name.",

--- a/pkg/deploy/taskdir/definitions/def_0_3_test.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3_test.go
@@ -838,7 +838,7 @@ func TestDefinitionToUpdateTaskRequest_0_3(t *testing.T) {
 				Name:       "REST Task",
 				Slug:       "rest_task",
 				Parameters: []api.Parameter{},
-				Configs:    []api.ConfigAttachment{},
+				Configs:    &[]api.ConfigAttachment{},
 				Kind:       build.TaskKindREST,
 				KindOptions: build.KindOptions{
 					"method":    "POST",
@@ -1077,7 +1077,7 @@ func TestDefinitionToUpdateTaskRequest_0_3(t *testing.T) {
 				Name:       "REST Task",
 				Slug:       "rest_task",
 				Parameters: []api.Parameter{},
-				Configs: []api.ConfigAttachment{
+				Configs: &[]api.ConfigAttachment{
 					{
 						NameTag: "CONFIG_VARIABLE_1",
 					},

--- a/pkg/deploy/taskdir/definitions/def_0_3_test.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3_test.go
@@ -16,7 +16,7 @@ var fullYAML = []byte(
 slug: hello_world
 description: A starter task.
 parameters:
-- name: Name
+- name: NameTag
   slug: name
   type: shorttext
   description: Someone's name.
@@ -34,7 +34,7 @@ var fullJSON = []byte(
 	"description": "A starter task.",
 	"parameters": [
 		{
-			"name": "Name",
+			"name": "NameTag",
 			"slug": "name",
 			"type": "shorttext",
 			"description": "Someone's name.",
@@ -53,7 +53,7 @@ var yamlWithDefault = []byte(
 slug: hello_world
 description: A starter task.
 parameters:
-- name: Name
+- name: NameTag
   slug: name
   type: shorttext
   description: Someone's name.
@@ -70,7 +70,7 @@ var jsonWithDefault = []byte(
 	"description": "A starter task.",
 	"parameters": [
 		{
-			"name": "Name",
+			"name": "NameTag",
 			"slug": "name",
 			"type": "shorttext",
 			"description": "Someone's name.",
@@ -89,7 +89,7 @@ var fullDef = Definition_0_3{
 	Description: "A starter task.",
 	Parameters: []ParameterDefinition_0_3{
 		{
-			Name:        "Name",
+			Name:        "NameTag",
 			Slug:        "name",
 			Type:        "shorttext",
 			Description: "Someone's name.",
@@ -109,7 +109,7 @@ var defWithDefault = Definition_0_3{
 	Description: "A starter task.",
 	Parameters: []ParameterDefinition_0_3{
 		{
-			Name:        "Name",
+			Name:        "NameTag",
 			Slug:        "name",
 			Type:        "shorttext",
 			Description: "Someone's name.",
@@ -643,6 +643,64 @@ func TestTaskToDefinition_0_3(t *testing.T) {
 				AllowSelfApprovals: nil,
 			},
 		},
+		{
+			name: "check configs",
+			resources: []api.Resource{
+				{
+					ID:   "res20220111foobarx",
+					Name: "httpbin",
+				},
+			},
+			task: api.Task{
+				Name:      "REST Task",
+				Slug:      "rest_task",
+				Arguments: []string{"{{__stdAPIRequest}}"},
+				Configs: []api.ConfigAttachment{
+					{
+						NameTag: "CONFIG_NAME_1",
+					},
+					{
+						NameTag: "CONFIG_NAME_2",
+					},
+				},
+				Kind: build.TaskKindREST,
+				KindOptions: build.KindOptions{
+					"method": "GET",
+					"path":   "/get",
+					"urlParams": map[string]interface{}{
+						"foo": "bar",
+					},
+					"headers": map[string]interface{}{
+						"bar": "foo",
+					},
+					"bodyType": "json",
+					"body":     "",
+					"formData": map[string]interface{}{},
+				},
+				Resources: map[string]string{
+					"rest": "res20220111foobarx",
+				},
+			},
+			definition: Definition_0_3{
+				Name: "REST Task",
+				Slug: "rest_task",
+				REST: &RESTDefinition_0_3{
+					Resource: "httpbin",
+					Method:   "GET",
+					Path:     "/get",
+					URLParams: map[string]interface{}{
+						"foo": "bar",
+					},
+					Headers: map[string]interface{}{
+						"bar": "foo",
+					},
+					BodyType: "json",
+					Body:     "",
+					FormData: map[string]interface{}{},
+					Configs:  []string{"CONFIG_NAME_1", "CONFIG_NAME_2"},
+				},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			assert := require.New(t)
@@ -779,6 +837,7 @@ func TestDefinitionToUpdateTaskRequest_0_3(t *testing.T) {
 				Name:       "REST Task",
 				Slug:       "rest_task",
 				Parameters: []api.Parameter{},
+				Configs:    []api.ConfigAttachment{},
 				Kind:       build.TaskKindREST,
 				KindOptions: build.KindOptions{
 					"method":    "POST",
@@ -996,6 +1055,57 @@ func TestDefinitionToUpdateTaskRequest_0_3(t *testing.T) {
 				ExecuteRules: api.UpdateExecuteRulesRequest{
 					DisallowSelfApprove: pointers.Bool(false),
 					RequireRequests:     pointers.Bool(false),
+				},
+			},
+		},
+		{
+			name: "check configs",
+			definition: Definition_0_3{
+				Name: "REST Task",
+				Slug: "rest_task",
+				REST: &RESTDefinition_0_3{
+					Resource: "rest",
+					Method:   "POST",
+					Path:     "/post",
+					BodyType: "json",
+					Body:     `{"foo": "bar"}`,
+					Configs:  []string{"CONFIG_VARIABLE_1", "CONFIG_VARIABLE_2"},
+				},
+			},
+			request: api.UpdateTaskRequest{
+				Name:       "REST Task",
+				Slug:       "rest_task",
+				Parameters: []api.Parameter{},
+				Configs: []api.ConfigAttachment{
+					{
+						NameTag: "CONFIG_VARIABLE_1",
+					},
+					{
+						NameTag: "CONFIG_VARIABLE_2",
+					},
+				},
+				Kind: build.TaskKindREST,
+				KindOptions: build.KindOptions{
+					"method":    "POST",
+					"path":      "/post",
+					"urlParams": map[string]interface{}{},
+					"headers":   map[string]interface{}{},
+					"bodyType":  "json",
+					"body":      `{"foo": "bar"}`,
+					"formData":  map[string]interface{}{},
+				},
+				Resources: map[string]string{
+					"rest": "rest_id",
+				},
+				ExecuteRules: api.UpdateExecuteRulesRequest{
+					DisallowSelfApprove: pointers.Bool(false),
+					RequireRequests:     pointers.Bool(false),
+				},
+			},
+			resources: []api.Resource{
+				{
+					ID:   "rest_id",
+					Name: "rest",
 				},
 			},
 		},

--- a/pkg/deploy/taskdir/definitions/def_0_3_test.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3_test.go
@@ -452,6 +452,7 @@ func TestTaskToDefinition_0_3(t *testing.T) {
 					BodyType: "json",
 					Body:     "",
 					FormData: map[string]interface{}{},
+					Configs:  []string{},
 				},
 			},
 		},
@@ -655,7 +656,7 @@ func TestTaskToDefinition_0_3(t *testing.T) {
 				Name:      "REST Task",
 				Slug:      "rest_task",
 				Arguments: []string{"{{__stdAPIRequest}}"},
-				Configs: &[]api.ConfigAttachment{
+				Configs: []api.ConfigAttachment{
 					{
 						NameTag: "CONFIG_NAME_1",
 					},

--- a/pkg/deploy/taskdir/definitions/def_0_3_test.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3_test.go
@@ -452,6 +452,7 @@ func TestTaskToDefinition_0_3(t *testing.T) {
 					BodyType: "json",
 					Body:     "",
 					FormData: map[string]interface{}{},
+					Configs:  []string{},
 				},
 			},
 		},

--- a/pkg/deploy/taskdir/definitions/def_0_3_test.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3_test.go
@@ -452,7 +452,6 @@ func TestTaskToDefinition_0_3(t *testing.T) {
 					BodyType: "json",
 					Body:     "",
 					FormData: map[string]interface{}{},
-					Configs:  []string{},
 				},
 			},
 		},
@@ -656,7 +655,7 @@ func TestTaskToDefinition_0_3(t *testing.T) {
 				Name:      "REST Task",
 				Slug:      "rest_task",
 				Arguments: []string{"{{__stdAPIRequest}}"},
-				Configs: []api.ConfigAttachment{
+				Configs: &[]api.ConfigAttachment{
 					{
 						NameTag: "CONFIG_NAME_1",
 					},

--- a/pkg/deploy/taskdir/definitions/fixtures/rest.task.yaml
+++ b/pkg/deploy/taskdir/definitions/fixtures/rest.task.yaml
@@ -72,10 +72,10 @@ rest:
   # formData:
   #   name: Alfred Pennyworth
 
-  # A list of config variables that are attached to this task.
+  # A list of config variables that this task can access.
   # configs:
-  #   - config_variable_1
-  #   - config_variable_2
+  #   - API_KEY
+  #   - DB_PASSWORD
 
 # Set label constraints to restrict this task to run only on agents with
 # matching labels.

--- a/pkg/deploy/taskdir/definitions/fixtures/rest.task.yaml
+++ b/pkg/deploy/taskdir/definitions/fixtures/rest.task.yaml
@@ -72,6 +72,11 @@ rest:
   # formData:
   #   name: Alfred Pennyworth
 
+  # A list of config variables that are attached to this task.
+  # configs:
+  #   - config_variable_1
+  #   - config_variable_2
+
 # Set label constraints to restrict this task to run only on agents with
 # matching labels.
 # constraints:

--- a/pkg/deploy/taskdir/definitions/fixtures/sql.task.yaml
+++ b/pkg/deploy/taskdir/definitions/fixtures/sql.task.yaml
@@ -56,6 +56,11 @@ sql:
   # Default: auto.
   # transactionMode: readWrite
 
+  # A list of config variables that are attached to this task.
+  # configs:
+  #   - config_variable_1
+  #   - config_variable_2
+
 # Set label constraints to restrict this task to run only on agents with
 # matching labels.
 # constraints:

--- a/pkg/deploy/taskdir/definitions/fixtures/sql.task.yaml
+++ b/pkg/deploy/taskdir/definitions/fixtures/sql.task.yaml
@@ -56,10 +56,10 @@ sql:
   # Default: auto.
   # transactionMode: readWrite
 
-  # A list of config variables that are attached to this task.
+  # A list of config variables that this task can access.
   # configs:
-  #   - config_variable_1
-  #   - config_variable_2
+  #   - API_KEY
+  #   - DB_PASSWORD
 
 # Set label constraints to restrict this task to run only on agents with
 # matching labels.

--- a/pkg/deploy/taskdir/definitions/schema_0_3.json
+++ b/pkg/deploy/taskdir/definitions/schema_0_3.json
@@ -206,7 +206,8 @@
                   "description": "The transaction mode to use.",
                   "default": "auto",
                   "enum": ["auto", "readOnly", "readWrite", "none"]
-                }
+                },
+                "configs": { "$ref": "#/$defs/configs" }
               },
               "additionalProperties": false,
               "required": ["resource", "entrypoint"]
@@ -266,7 +267,8 @@
                   "patternProperties": {
                     ".*": { "type": ["string", "boolean", "number"] }
                   }
-                }
+                },
+                "configs": { "$ref": "#/$defs/configs" }
               },
               "additionalProperties": false,
               "required": ["resource", "method", "path", "bodyType"]
@@ -417,6 +419,14 @@
             }
           ]
         }
+      }
+    },
+    "configs": {
+      "description": "A list of config variables that are attached to this task.",
+      "examples": ["config_variable"],
+      "type": "array",
+      "items": {
+        "type": "string"
       }
     },
     "baseDefinition": {

--- a/pkg/deploy/taskdir/definitions/schema_0_3.json
+++ b/pkg/deploy/taskdir/definitions/schema_0_3.json
@@ -422,8 +422,8 @@
       }
     },
     "configs": {
-      "description": "A list of config variables that are attached to this task.",
-      "examples": ["config_variable"],
+      "description": "A list of config variables that this task can access.",
+      "examples": ["API_KEY", "DB_PASSWORD"],
       "type": "array",
       "items": {
         "type": "string"

--- a/pkg/deploy/taskdir/definitions/yaml_templates.go
+++ b/pkg/deploy/taskdir/definitions/yaml_templates.go
@@ -161,10 +161,10 @@ sql:
   # Default: auto.
   # transactionMode: readWrite
 
-  # A list of config variables that are attached to this task.
+  # A list of config variables that this task can access.
   # configs:
-  #   - config_variable_1
-  #   - config_variable_2
+  #   - API_KEY
+  #   - DB_PASSWORD
 `
 
 const restTemplate = `
@@ -205,8 +205,8 @@ rest:
   # formData:
   #   name: Alfred Pennyworth
 
-  # A list of config variables that are attached to this task.
+  # A list of config variables that this task can access.
   # configs:
-  #   - config_variable_1
-  #   - config_variable_2
+  #   - API_KEY
+  #   - DB_PASSWORD
 `

--- a/pkg/deploy/taskdir/definitions/yaml_templates.go
+++ b/pkg/deploy/taskdir/definitions/yaml_templates.go
@@ -160,6 +160,11 @@ sql:
   # The transaction mode to use. Valid values: auto, readOnly, readWrite, none.
   # Default: auto.
   # transactionMode: readWrite
+
+  # A list of config variables that are attached to this task.
+  # configs:
+  #   - config_variable_1
+  #   - config_variable_2
 `
 
 const restTemplate = `
@@ -199,4 +204,9 @@ rest:
   # (https://docs.airplane.dev/runbooks/javascript-templates).
   # formData:
   #   name: Alfred Pennyworth
+
+  # A list of config variables that are attached to this task.
+  # configs:
+  #   - config_variable_1
+  #   - config_variable_2
 `

--- a/pkg/runtime/typescript/typescript.go
+++ b/pkg/runtime/typescript/typescript.go
@@ -22,7 +22,7 @@ var code = template.Must(template.New("ts").Parse(`{{with .Comment -}}
 {{end -}}
 type Params = {
   {{- range .Params }}
-  {{ .NameTag }}: {{ .Type }}
+  {{ .Name }}: {{ .Type }}
   {{- end }}
 }
 

--- a/pkg/runtime/typescript/typescript.go
+++ b/pkg/runtime/typescript/typescript.go
@@ -22,7 +22,7 @@ var code = template.Must(template.New("ts").Parse(`{{with .Comment -}}
 {{end -}}
 type Params = {
   {{- range .Params }}
-  {{ .Name }}: {{ .Type }}
+  {{ .NameTag }}: {{ .Type }}
   {{- end }}
 }
 


### PR DESCRIPTION
## Description
This PR adds a `Configs` field to the task definition YAML for REST and SQL tasks, similar to how there is an `EnvVars` field for code tasks. It also adds a `Configs` field to a couple structs so that the CLI can deploy a task with config attachments. 

## Test plan
Unit tests
