### PR TITLE
Expose config attachments from definition

### DIFF
--- a/pkg/deploy/taskdir/definitions/def_0_3.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3.go
@@ -54,6 +54,7 @@ type taskKind_0_3 interface {
 	getKindOptions() (build.KindOptions, error)
 	getEntrypoint() (string, error)
 	getEnv() (api.TaskEnv, error)
+	getConfigAttachments() []api.ConfigAttachment
 }
 
 var _ taskKind_0_3 = &ImageDefinition_0_3{}
@@ -117,6 +118,10 @@ func (d *ImageDefinition_0_3) getEnv() (api.TaskEnv, error) {
 	return d.EnvVars, nil
 }
 
+func (d *ImageDefinition_0_3) getConfigAttachments() []api.ConfigAttachment {
+	return []api.ConfigAttachment{}
+}
+
 var _ taskKind_0_3 = &DenoDefinition_0_3{}
 
 type DenoDefinition_0_3 struct {
@@ -174,6 +179,10 @@ func (d *DenoDefinition_0_3) getEnv() (api.TaskEnv, error) {
 	return d.EnvVars, nil
 }
 
+func (d *DenoDefinition_0_3) getConfigAttachments() []api.ConfigAttachment {
+	return []api.ConfigAttachment{}
+}
+
 var _ taskKind_0_3 = &DockerfileDefinition_0_3{}
 
 type DockerfileDefinition_0_3 struct {
@@ -222,6 +231,10 @@ func (d *DockerfileDefinition_0_3) getEntrypoint() (string, error) {
 
 func (d *DockerfileDefinition_0_3) getEnv() (api.TaskEnv, error) {
 	return d.EnvVars, nil
+}
+
+func (d *DockerfileDefinition_0_3) getConfigAttachments() []api.ConfigAttachment {
+	return []api.ConfigAttachment{}
 }
 
 var _ taskKind_0_3 = &GoDefinition_0_3{}
@@ -279,6 +292,10 @@ func (d *GoDefinition_0_3) getEntrypoint() (string, error) {
 
 func (d *GoDefinition_0_3) getEnv() (api.TaskEnv, error) {
 	return d.EnvVars, nil
+}
+
+func (d *GoDefinition_0_3) getConfigAttachments() []api.ConfigAttachment {
+	return []api.ConfigAttachment{}
 }
 
 var _ taskKind_0_3 = &NodeDefinition_0_3{}
@@ -347,6 +364,10 @@ func (d *NodeDefinition_0_3) getEnv() (api.TaskEnv, error) {
 	return d.EnvVars, nil
 }
 
+func (d *NodeDefinition_0_3) getConfigAttachments() []api.ConfigAttachment {
+	return []api.ConfigAttachment{}
+}
+
 var _ taskKind_0_3 = &PythonDefinition_0_3{}
 
 type PythonDefinition_0_3 struct {
@@ -402,6 +423,10 @@ func (d *PythonDefinition_0_3) getEntrypoint() (string, error) {
 
 func (d *PythonDefinition_0_3) getEnv() (api.TaskEnv, error) {
 	return d.EnvVars, nil
+}
+
+func (d *PythonDefinition_0_3) getConfigAttachments() []api.ConfigAttachment {
+	return []api.ConfigAttachment{}
 }
 
 var _ taskKind_0_3 = &ShellDefinition_0_3{}
@@ -461,6 +486,10 @@ func (d *ShellDefinition_0_3) getEnv() (api.TaskEnv, error) {
 	return d.EnvVars, nil
 }
 
+func (d *ShellDefinition_0_3) getConfigAttachments() []api.ConfigAttachment {
+	return []api.ConfigAttachment{}
+}
+
 var _ taskKind_0_3 = &SQLDefinition_0_3{}
 
 type SQLDefinition_0_3 struct {
@@ -516,13 +545,6 @@ func (d *SQLDefinition_0_3) fillInUpdateTaskRequest(ctx context.Context, client 
 	} else {
 		return errors.Errorf("unknown resource: %s", d.Resource)
 	}
-	configs := make([]api.ConfigAttachment, len(d.Configs))
-	for i, configName := range d.Configs {
-		configs[i] = api.ConfigAttachment{
-			NameTag: configName,
-		}
-	}
-	req.Configs = &configs
 	return nil
 }
 
@@ -614,6 +636,15 @@ func (d *SQLDefinition_0_3) getEnv() (api.TaskEnv, error) {
 	return nil, nil
 }
 
+func (d *SQLDefinition_0_3) getConfigAttachments() []api.ConfigAttachment {
+	configAttachments := make([]api.ConfigAttachment, len(d.Configs))
+	for i, configName := range d.Configs {
+		configAttachments[i] = api.ConfigAttachment{NameTag: configName}
+	}
+
+	return configAttachments
+}
+
 var _ taskKind_0_3 = &RESTDefinition_0_3{}
 
 type RESTDefinition_0_3 struct {
@@ -640,13 +671,6 @@ func (d *RESTDefinition_0_3) fillInUpdateTaskRequest(ctx context.Context, client
 	} else {
 		return errors.Errorf("unknown resource: %s", d.Resource)
 	}
-	configs := make([]api.ConfigAttachment, len(d.Configs))
-	for i, configName := range d.Configs {
-		configs[i] = api.ConfigAttachment{
-			NameTag: configName,
-		}
-	}
-	req.Configs = &configs
 	return nil
 }
 
@@ -753,6 +777,15 @@ func (d *RESTDefinition_0_3) getEntrypoint() (string, error) {
 
 func (d *RESTDefinition_0_3) getEnv() (api.TaskEnv, error) {
 	return nil, nil
+}
+
+func (d *RESTDefinition_0_3) getConfigAttachments() []api.ConfigAttachment {
+	configAttachments := make([]api.ConfigAttachment, len(d.Configs))
+	for i, configName := range d.Configs {
+		configAttachments[i] = api.ConfigAttachment{NameTag: configName}
+	}
+
+	return configAttachments
 }
 
 type ParameterDefinition_0_3 struct {
@@ -1201,6 +1234,12 @@ func (d Definition_0_3) addKindSpecificsToUpdateTaskRequest(ctx context.Context,
 	}
 	req.Env = env
 
+	configAttachments, err := d.GetConfigAttachments()
+	if err != nil {
+		return err
+	}
+	req.Configs = &configAttachments
+
 	taskKind, err := d.taskKind()
 	if err != nil {
 		return err
@@ -1248,6 +1287,14 @@ func (d *Definition_0_3) GetEnv() (api.TaskEnv, error) {
 		return nil, err
 	}
 	return taskKind.getEnv()
+}
+
+func (d *Definition_0_3) GetConfigAttachments() ([]api.ConfigAttachment, error) {
+	taskKind, err := d.taskKind()
+	if err != nil {
+		return nil, err
+	}
+	return taskKind.getConfigAttachments(), nil
 }
 
 func (d *Definition_0_3) GetSlug() string {

--- a/pkg/deploy/taskdir/definitions/def_0_3_test.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3_test.go
@@ -737,6 +737,7 @@ func TestDefinitionToUpdateTaskRequest_0_3(t *testing.T) {
 				Name:        "Test Task",
 				Slug:        "test_task",
 				Description: "A task for testing",
+				Configs:     &[]api.ConfigAttachment{},
 				Parameters:  []api.Parameter{},
 				Kind:        build.TaskKindPython,
 				KindOptions: build.KindOptions{
@@ -762,6 +763,7 @@ func TestDefinitionToUpdateTaskRequest_0_3(t *testing.T) {
 				Name:       "Node Task",
 				Slug:       "node_task",
 				Parameters: []api.Parameter{},
+				Configs:    &[]api.ConfigAttachment{},
 				Kind:       build.TaskKindNode,
 				KindOptions: build.KindOptions{
 					"entrypoint":  "main.ts",
@@ -786,6 +788,7 @@ func TestDefinitionToUpdateTaskRequest_0_3(t *testing.T) {
 				Name:       "Shell Task",
 				Slug:       "shell_task",
 				Parameters: []api.Parameter{},
+				Configs:    &[]api.ConfigAttachment{},
 				Kind:       build.TaskKindShell,
 				KindOptions: build.KindOptions{
 					"entrypoint": "main.sh",
@@ -811,6 +814,7 @@ func TestDefinitionToUpdateTaskRequest_0_3(t *testing.T) {
 				Name:       "Image Task",
 				Slug:       "image_task",
 				Parameters: []api.Parameter{},
+				Configs:    &[]api.ConfigAttachment{},
 				Command:    []string{"bash"},
 				Arguments:  []string{"-c", `echo "foobar"`},
 				Kind:       build.TaskKindImage,
@@ -880,6 +884,7 @@ func TestDefinitionToUpdateTaskRequest_0_3(t *testing.T) {
 				Name:        "Test Task",
 				Slug:        "test_task",
 				Parameters:  []api.Parameter{},
+				Configs:     &[]api.ConfigAttachment{},
 				Description: "A task for testing",
 				Kind:        build.TaskKindPython,
 				KindOptions: build.KindOptions{
@@ -907,6 +912,7 @@ func TestDefinitionToUpdateTaskRequest_0_3(t *testing.T) {
 				Name:        "Test Task",
 				Slug:        "test_task",
 				Parameters:  []api.Parameter{},
+				Configs:     &[]api.ConfigAttachment{},
 				Description: "A task for testing",
 				Kind:        build.TaskKindPython,
 				KindOptions: build.KindOptions{
@@ -1049,7 +1055,8 @@ func TestDefinitionToUpdateTaskRequest_0_3(t *testing.T) {
 						},
 					},
 				},
-				Kind: build.TaskKindPython,
+				Configs: &[]api.ConfigAttachment{},
+				Kind:    build.TaskKindPython,
 				KindOptions: build.KindOptions{
 					"entrypoint": "main.py",
 				},

--- a/pkg/deploy/taskdir/definitions/interface.go
+++ b/pkg/deploy/taskdir/definitions/interface.go
@@ -30,6 +30,7 @@ type DefinitionInterface interface {
 
 	GetKindAndOptions() (build.TaskKind, build.KindOptions, error)
 	GetEnv() (api.TaskEnv, error)
+	GetConfigAttachments() ([]api.ConfigAttachment, error)
 	GetSlug() string
 	GetName() string
 	UpgradeJST() error


### PR DESCRIPTION
## Description
We need to be able to get a definition's config attachments in order for the CLI to check that the config variables exist - this PR adds a method to the definition interface to do that.

## Test plan
Unit tests
