### PR TITLE
Add optional runtime field in task configs

### DIFF
--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -36,6 +36,7 @@ type Task struct {
 	Resources                  Resources          `json:"resources" yaml:"resources"`
 	Kind                       build.TaskKind     `json:"kind" yaml:"kind"`
 	KindOptions                build.KindOptions  `json:"kindOptions" yaml:"kindOptions"`
+	Runtime                    build.TaskRuntime  `json:"runtime" yaml:"runtime"`
 	Repo                       string             `json:"repo" yaml:"repo"`
 	RequireExplicitPermissions bool               `json:"requireExplicitPermissions" yaml:"-"`
 	Permissions                Permissions        `json:"permissions" yaml:"-"`
@@ -84,6 +85,7 @@ type UpdateTaskRequest struct {
 	Resources                  map[string]string         `json:"resources"`
 	Kind                       build.TaskKind            `json:"kind"`
 	KindOptions                build.KindOptions         `json:"kindOptions"`
+	Runtime                    build.TaskRuntime         `json:"taskRuntime"`
 	Repo                       string                    `json:"repo"`
 	RequireExplicitPermissions *bool                     `json:"requireExplicitPermissions"`
 	Permissions                *Permissions              `json:"permissions"`

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -85,7 +85,7 @@ type UpdateTaskRequest struct {
 	Resources                  map[string]string         `json:"resources"`
 	Kind                       build.TaskKind            `json:"kind"`
 	KindOptions                build.KindOptions         `json:"kindOptions"`
-	Runtime                    build.TaskRuntime         `json:"taskRuntime"`
+	Runtime                    build.TaskRuntime         `json:"runtime"`
 	Repo                       string                    `json:"repo"`
 	RequireExplicitPermissions *bool                     `json:"requireExplicitPermissions"`
 	Permissions                *Permissions              `json:"permissions"`

--- a/pkg/build/types.go
+++ b/pkg/build/types.go
@@ -22,6 +22,13 @@ const (
 	TaskKindREST TaskKind = "rest"
 )
 
+type TaskRuntime string
+
+const (
+	TaskRuntimeLegacy  TaskRuntime = ""
+	TaskRuntimeDurable TaskRuntime = "durable"
+)
+
 // Value represents a value.
 type Value interface{}
 

--- a/pkg/deploy/taskdir/definitions/def_0_3.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3.go
@@ -41,6 +41,7 @@ type Definition_0_3 struct {
 	RequireRequests    bool              `json:"requireRequests,omitempty"`
 	AllowSelfApprovals *bool             `json:"allowSelfApprovals,omitempty"`
 	Timeout            int               `json:"timeout,omitempty"`
+	Runtime            build.TaskRuntime `json:"runtime,omitempty"`
 
 	buildConfig  build.BuildConfig
 	defnFilePath string
@@ -1490,6 +1491,9 @@ func (d *Definition_0_3) GetBuildConfig() (build.BuildConfig, error) {
 	for key, val := range options {
 		config[key] = val
 	}
+
+	// Pass runtime through to builder
+	config["runtime"] = d.Runtime
 
 	for key, val := range d.buildConfig {
 		if val == nil { // Nil masks out the value.

--- a/pkg/deploy/taskdir/definitions/def_0_3.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3.go
@@ -1125,6 +1125,7 @@ func (d Definition_0_3) GetUpdateTaskRequest(ctx context.Context, client api.IAP
 		Name:        d.Name,
 		Description: d.Description,
 		Timeout:     d.Timeout,
+		Runtime:     d.Runtime,
 		ExecuteRules: api.UpdateExecuteRulesRequest{
 			RequireRequests: &d.RequireRequests,
 		},

--- a/pkg/deploy/taskdir/definitions/def_0_3_test.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3_test.go
@@ -25,6 +25,7 @@ parameters:
 python:
   entrypoint: hello_world.py
 timeout: 3600
+runtime: durable
 `)
 
 var fullJSON = []byte(
@@ -45,7 +46,8 @@ var fullJSON = []byte(
 	"python": {
 		"entrypoint": "hello_world.py"
 	},
-	"timeout": 3600
+	"timeout": 3600,
+	"runtime": "durable"
 }`)
 
 var yamlWithDefault = []byte(
@@ -100,6 +102,7 @@ var fullDef = Definition_0_3{
 	Python: &PythonDefinition_0_3{
 		Entrypoint: "hello_world.py",
 	},
+	Runtime: "durable",
 	Timeout: 3600,
 }
 

--- a/pkg/deploy/taskdir/definitions/schema_0_3.json
+++ b/pkg/deploy/taskdir/definitions/schema_0_3.json
@@ -288,6 +288,7 @@
     "requireRequests": true,
     "allowSelfApprovals": true,
     "timeout": true,
+    "runtime": true,
 
     "node": true,
     "python": true,
@@ -476,6 +477,11 @@
           "default": 3600,
           "type": "number",
           "exclusiveMinimum": 0
+        },
+        "runtime": {
+          "description": "Set the runtime used for this task.",
+          "enum": ["", "durable"],
+          "default": ""
         }
       },
       "required": ["name", "slug"]


### PR DESCRIPTION
## Description
This change adds support for a top-level `runtime` field in task configs. This will be used to indicate durability, among other use cases. See https://github.com/airplanedev/airport/pull/2147 for the associated airport-side changes.

cc: @colinking @calufornia 

## Test plan
Testing completed successfully via building the cli with this revision and doing some deploys to verify that nothing bad happened.
