### PR TITLE
Skip archived tasks

### DIFF
--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -42,6 +42,7 @@ type Task struct {
 	Permissions                Permissions        `json:"permissions" yaml:"-"`
 	ExecuteRules               ExecuteRules       `json:"executeRules" yaml:"-"`
 	Timeout                    int                `json:"timeout" yaml:"timeout"`
+	IsArchived                 bool               `json:"isArchived" yaml:"isArchived"`
 	InterpolationMode          string             `json:"interpolationMode" yaml:"-"`
 }
 
@@ -51,8 +52,9 @@ type GetTaskRequest struct {
 }
 
 type TaskMetadata struct {
-	ID   string `json:"id"`
-	Slug string `json:"slug"`
+	ID         string `json:"id"`
+	Slug       string `json:"slug"`
+	IsArchived bool   `json:"isArchived"`
 }
 
 type CreateBuildUploadRequest struct {

--- a/pkg/api/mock/client_mock.go
+++ b/pkg/api/mock/client_mock.go
@@ -27,8 +27,9 @@ func (mc *MockClient) GetTaskMetadata(ctx context.Context, slug string) (res api
 		return api.TaskMetadata{}, &api.TaskMissingError{AppURL: "api/", Slug: slug}
 	}
 	return api.TaskMetadata{
-		ID:   task.ID,
-		Slug: task.Slug,
+		ID:         task.ID,
+		Slug:       task.Slug,
+		IsArchived: task.IsArchived,
 	}, nil
 }
 

--- a/pkg/deploy/discover/defn_discover.go
+++ b/pkg/deploy/discover/defn_discover.go
@@ -97,6 +97,10 @@ func (dd *DefnDiscoverer) GetTaskConfig(ctx context.Context, file string) (*Task
 		}
 		metadata = *mptr
 	}
+	if metadata.IsArchived {
+		dd.Logger.Warning(`Task with slug %s is archived, skipping deploy.`, metadata.Slug)
+		return nil, nil
+	}
 	tc.TaskID = metadata.ID
 
 	entrypoint, err := def.GetAbsoluteEntrypoint()

--- a/pkg/deploy/discover/defn_discover.go
+++ b/pkg/deploy/discover/defn_discover.go
@@ -91,14 +91,14 @@ func (dd *DefnDiscoverer) GetTaskConfig(ctx context.Context, file string) (*Task
 			return nil, err
 		} else if mptr == nil {
 			if dd.Logger != nil {
-				dd.Logger.Warning(`Task with slug %s does not exist, skipping deploy.`, def.GetSlug())
+				dd.Logger.Warning(`Task with slug %s does not exist, skipping deployment.`, def.GetSlug())
 			}
 			return nil, nil
 		}
 		metadata = *mptr
 	}
 	if metadata.IsArchived {
-		dd.Logger.Warning(`Task with slug %s is archived, skipping deploy.`, metadata.Slug)
+		dd.Logger.Warning(`Task with slug %s is archived, skipping deployment.`, metadata.Slug)
 		return nil, nil
 	}
 	tc.TaskID = metadata.ID

--- a/pkg/deploy/discover/discover_test.go
+++ b/pkg/deploy/discover/discover_test.go
@@ -170,6 +170,20 @@ func TestDiscoverTasks(t *testing.T) {
 			expectedErr:   false,
 		},
 		{
+			name:  "defn task archived - deploy skipped",
+			paths: []string{"./fixtures/defn.task.yaml"},
+			existingTasks: map[string]api.Task{
+				"my_task": {ID: "tsk123", Slug: "my_task", Kind: build.TaskKindNode, InterpolationMode: "jst", IsArchived: true},
+			},
+		},
+		{
+			name:  "script task archived - deploy skipped",
+			paths: []string{"./fixtures/single_task.js"},
+			existingTasks: map[string]api.Task{
+				"my_task": {ID: "tsk123", Slug: "my_task", Kind: build.TaskKindNode, InterpolationMode: "jst", IsArchived: true},
+			},
+		},
+		{
 			name:  "same task, multiple discoverers",
 			paths: []string{"./fixtures/defn.task.yaml", "./fixtures/single_task.js"},
 			existingTasks: map[string]api.Task{

--- a/pkg/deploy/discover/script_discover.go
+++ b/pkg/deploy/discover/script_discover.go
@@ -46,11 +46,11 @@ func (sd *ScriptDiscoverer) GetTaskConfig(ctx context.Context, file string) (*Ta
 			return nil, errors.Wrap(err, "unable to get task")
 		}
 
-		sd.Logger.Warning(`Task with slug %s does not exist, skipping deploy.`, slug)
+		sd.Logger.Warning(`Task with slug %s does not exist, skipping deployment.`, slug)
 		return nil, nil
 	}
 	if task.IsArchived {
-		sd.Logger.Warning(`Task with slug %s is archived, skipping deploy.`, slug)
+		sd.Logger.Warning(`Task with slug %s is archived, skipping deployment.`, slug)
 		return nil, nil
 	}
 

--- a/pkg/deploy/discover/script_discover.go
+++ b/pkg/deploy/discover/script_discover.go
@@ -49,6 +49,10 @@ func (sd *ScriptDiscoverer) GetTaskConfig(ctx context.Context, file string) (*Ta
 		sd.Logger.Warning(`Task with slug %s does not exist, skipping deploy.`, slug)
 		return nil, nil
 	}
+	if task.IsArchived {
+		sd.Logger.Warning(`Task with slug %s is archived, skipping deploy.`, slug)
+		return nil, nil
+	}
 
 	def, err := definitions.NewDefinitionFromTask(ctx, sd.Client, task)
 	if err != nil {


### PR DESCRIPTION
## Description
Skip discovering archived tasks. Print a warning to the console.

## Test plan
Unit tested

FIXES https://linear.app/airplane/issue/AIR-3596/archived-task-should-gracefully-error-when-deploying