### PR TITLE
Remove node v12 and v15 references from task definition template

### DIFF
--- a/pkg/build/node_test.go
+++ b/pkg/build/node_test.go
@@ -81,15 +81,6 @@ func TestNodeBuilder(t *testing.T) {
 			Options: KindOptions{
 				"shim":        "true",
 				"entrypoint":  "main.ts",
-				"nodeVersion": "12",
-			},
-		},
-		{
-			Root: "typescript/esnext",
-			Kind: TaskKindNode,
-			Options: KindOptions{
-				"shim":        "true",
-				"entrypoint":  "main.ts",
 				"nodeVersion": "14",
 			},
 		},

--- a/pkg/deploy/taskdir/definitions/fixtures/node.task.yaml
+++ b/pkg/deploy/taskdir/definitions/fixtures/node.task.yaml
@@ -43,7 +43,7 @@ node:
   # can be absolute or relative to the location of the definition file.
   entrypoint: my_task.ts
 
-  # The version of Node to use. Valid values: 12, 14, 15, 16.
+  # The version of Node to use. Valid values: 14, 16.
   nodeVersion: "16"
 
   # A map of environment variables to use when running the task. The value

--- a/pkg/deploy/taskdir/definitions/yaml_templates.go
+++ b/pkg/deploy/taskdir/definitions/yaml_templates.go
@@ -63,7 +63,7 @@ node:
   # can be absolute or relative to the location of the definition file.
   entrypoint: {{.Entrypoint}}
 
-  # The version of Node to use. Valid values: 12, 14, 15, 16.
+  # The version of Node to use. Valid values: 14, 16.
   nodeVersion: "{{.NodeVersion}}"
 
   # A map of environment variables to use when running the task. The value


### PR DESCRIPTION
## Description
Per https://linear.app/airplane/issue/AIR-3536/deprecate-node-12-and-15, we're deprecating support for Node v12 and v15. This PR removes references to these versions from the task definition YAML templates.


## Test plan
Unit tests
