### PR TITLE
Add support for Node v18

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,7 +12,7 @@ export AIRPLANE_LIB_TAG=v0.0.1 && \
 
 ## Base images
 
-If you make changes to the base images -- `pkg/versions.json` -- then you'll need to push these into the public cache:
+If you make changes to the base images -- `pkg/build/versions.json` -- then you'll need to push these into the public cache:
 
 ```
 airplane dev scripts/cache/main.ts -- --gcp_project=airplane-stage

--- a/pkg/build/versions.json
+++ b/pkg/build/versions.json
@@ -1,5 +1,10 @@
 {
   "node": {
+    "18": {
+      "image": "registry.hub.docker.com/library/node",
+      "tag": "18.1.0-buster",
+      "digest": "sha256:9b2fc7ff617cd4b6beb123d452b56ad5fd3849dfaefda152c8d4c0836ccb1a9a"
+    },
     "16": {
       "image": "registry.hub.docker.com/library/node",
       "tag": "16.2.0-buster",

--- a/pkg/build/versions.json
+++ b/pkg/build/versions.json
@@ -3,7 +3,7 @@
     "18": {
       "image": "registry.hub.docker.com/library/node",
       "tag": "18.1.0-buster",
-      "digest": "sha256:9b2fc7ff617cd4b6beb123d452b56ad5fd3849dfaefda152c8d4c0836ccb1a9a"
+      "digest": "sha256:3b88dc7e2379f5adb2e2893e0d4cf1774e260c176e51a6a8fc0cb358a2749a3f"
     },
     "16": {
       "image": "registry.hub.docker.com/library/node",

--- a/pkg/deploy/taskdir/definitions/fixtures/node.task.yaml
+++ b/pkg/deploy/taskdir/definitions/fixtures/node.task.yaml
@@ -43,7 +43,7 @@ node:
   # can be absolute or relative to the location of the definition file.
   entrypoint: my_task.ts
 
-  # The version of Node to use. Valid values: 12, 14, 15, 16.
+  # The version of Node to use. Valid values: 12, 14, 15, 16, 18.
   nodeVersion: "16"
 
   # A map of environment variables to use when running the task. The value

--- a/pkg/deploy/taskdir/definitions/schema_0_3.json
+++ b/pkg/deploy/taskdir/definitions/schema_0_3.json
@@ -18,7 +18,7 @@
                 },
                 "nodeVersion": {
                   "description": "The version of Node to use.",
-                  "enum": ["12", "14", "15", "16"]
+                  "enum": ["12", "14", "15", "16", "18"]
                 },
                 "envVars": { "$ref": "#/$defs/envVars" }
               },

--- a/pkg/deploy/taskdir/definitions/yaml_templates.go
+++ b/pkg/deploy/taskdir/definitions/yaml_templates.go
@@ -63,7 +63,7 @@ node:
   # can be absolute or relative to the location of the definition file.
   entrypoint: {{.Entrypoint}}
 
-  # The version of Node to use. Valid values: 12, 14, 15, 16.
+  # The version of Node to use. Valid values: 12, 14, 15, 16, 18.
   nodeVersion: "{{.NodeVersion}}"
 
   # A map of environment variables to use when running the task. The value


### PR DESCRIPTION
## Description

We plan on adding support for node v18, per https://linear.app/airplane/issue/AIR-3549/support-node-18. This PR adds the latest v18 buster image to `versions.json` so that we can start building images with it.

Resolves AIR-3549

## Test plan
n/a

