### PR TITLE
Handle default values in configvar parameters

### DIFF
--- a/pkg/deploy/taskdir/definitions/def_0_3_test.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3_test.go
@@ -528,6 +528,33 @@ func TestTaskToDefinition_0_3(t *testing.T) {
 							Regex: "foo.*",
 						},
 					},
+					{
+						Name: "Config var",
+						Slug: "config_var",
+						Type: api.TypeConfigVar,
+						Default: map[string]interface{}{
+							"__airplaneType": "configvar",
+							"name":           "API_KEY",
+						},
+						Constraints: api.Constraints{
+							Options: []api.ConstraintOption{
+								{
+									Label: "API key",
+									Value: map[string]interface{}{
+										"__airplaneType": "configvar",
+										"name":           "API_KEY",
+									},
+								},
+								{
+									Label: "Other API key",
+									Value: map[string]interface{}{
+										"__airplaneType": "configvar",
+										"name":           "OTHER_API_KEY",
+									},
+								},
+							},
+						},
+					},
 				},
 				Arguments: []string{"{{JSON.stringify(params)}}"},
 				Kind:      build.TaskKindPython,
@@ -590,6 +617,24 @@ func TestTaskToDefinition_0_3(t *testing.T) {
 						Slug:  "regex",
 						Type:  "shorttext",
 						Regex: "foo.*",
+					},
+					{
+						Name: "Config var",
+						Slug: "config_var",
+						Type: "configvar",
+						Default: map[string]interface{}{
+							"config": "API_KEY",
+						},
+						Options: []OptionDefinition_0_3{
+							{
+								Label:  "API key",
+								Config: pointers.String("API_KEY"),
+							},
+							{
+								Label:  "Other API key",
+								Config: pointers.String("OTHER_API_KEY"),
+							},
+						},
 					},
 				},
 				Python: &PythonDefinition_0_3{
@@ -985,6 +1030,24 @@ func TestDefinitionToUpdateTaskRequest_0_3(t *testing.T) {
 						Type:  "shorttext",
 						Regex: "foo.*",
 					},
+					{
+						Name: "Config var",
+						Slug: "config_var",
+						Type: "configvar",
+						Default: map[string]interface{}{
+							"config": "API_KEY",
+						},
+						Options: []OptionDefinition_0_3{
+							{
+								Label:  "API key",
+								Config: pointers.String("API_KEY"),
+							},
+							{
+								Label:  "Other API key",
+								Config: pointers.String("OTHER_API_KEY"),
+							},
+						},
+					},
 				},
 				Python: &PythonDefinition_0_3{
 					Entrypoint: "main.py",
@@ -1055,6 +1118,33 @@ func TestDefinitionToUpdateTaskRequest_0_3(t *testing.T) {
 						Type: api.TypeString,
 						Constraints: api.Constraints{
 							Regex: "foo.*",
+						},
+					},
+					{
+						Name: "Config var",
+						Slug: "config_var",
+						Type: api.TypeConfigVar,
+						Default: map[string]interface{}{
+							"__airplaneType": "configvar",
+							"name":           "API_KEY",
+						},
+						Constraints: api.Constraints{
+							Options: []api.ConstraintOption{
+								{
+									Label: "API key",
+									Value: map[string]interface{}{
+										"__airplaneType": "configvar",
+										"name":           "API_KEY",
+									},
+								},
+								{
+									Label: "Other API key",
+									Value: map[string]interface{}{
+										"__airplaneType": "configvar",
+										"name":           "OTHER_API_KEY",
+									},
+								},
+							},
 						},
 					},
 				},

--- a/pkg/deploy/taskdir/definitions/schema_0_3.json
+++ b/pkg/deploy/taskdir/definitions/schema_0_3.json
@@ -340,7 +340,14 @@
           "oneOf": [
             { "type": "string" },
             { "type": "number" },
-            { "type": "boolean" }
+            { "type": "boolean" },
+            {
+              "type": "object",
+              "properties": {
+                "config": { "type": "string" }
+              },
+              "required": ["config"]
+            }
           ]
         },
         "required": {


### PR DESCRIPTION
## Description

Previously, `airplane init --from slug` would create an invalid definition file if the task contained a configvar parameter with a default value. This patch adds handling for default values in configvar parameters.

Example usage:

```
parameters:
- name: ConfigVar
  slug: configvar
  type: configvar
  default:
    config: database_url
  options:
  - label: ""
    config: database_url
  - label: ""
    config: db/dsn:local
```

Resolves AIR-3672.

## Test plan

Unit tests, tested locally.