### PR TITLE
Use authentication and TLS for temporal communication in node shim

### DIFF
--- a/pkg/build/durable/worker-and-activity-shim.js
+++ b/pkg/build/durable/worker-and-activity-shim.js
@@ -26,9 +26,22 @@ async function runWorker(params) {
     throw 'AP_NAMESPACE is not set in environment';
   }
 
+  const temporalToken = process.env.AP_TEMPORAL_TOKEN;
+  if (namespace === undefined) {
+    throw 'AP_TEMPORAL_TOKEN is not set in environment';
+  }
+
+  // We use TLS when hitting a remote Temporal API (i.e., behind a load balancer),
+  // but not a local one. The easiest way to tell the difference is by
+  // looking at the port.
+  const useTLS = temporalHost.endsWith(':443');
+
   const connection = await NativeConnection.create({
-    // TODO: Insert a token for auth purposes
     address: temporalHost,
+    headers: {
+      authorization: temporalToken,
+    },
+    tls: useTLS,
   });
 
   // Sinks allow us to log from workflows.

--- a/pkg/build/durable/worker-and-activity-shim.js
+++ b/pkg/build/durable/worker-and-activity-shim.js
@@ -27,7 +27,7 @@ async function runWorker(params) {
   }
 
   const temporalToken = process.env.AP_TEMPORAL_TOKEN;
-  if (namespace === undefined) {
+  if (temporalToken === undefined) {
     throw 'AP_TEMPORAL_TOKEN is not set in environment';
   }
 
@@ -35,6 +35,10 @@ async function runWorker(params) {
   // but not a local one. The easiest way to tell the difference is by
   // looking at the port.
   const useTLS = temporalHost.endsWith(':443');
+
+  console.log(
+    `Starting worker with temporal host ${temporalHost}, task queue ${taskQueue}, namespace ${namespace}, useTLS ${useTLS}`
+  );
 
   const connection = await NativeConnection.create({
     address: temporalHost,

--- a/pkg/build/node.go
+++ b/pkg/build/node.go
@@ -264,7 +264,7 @@ func GenShimPackageJSON(pathPackageJSON string, isDurable bool) ([]byte, error) 
 
 	if isDurable {
 		// TODO: Make this configurable
-		pjson.Dependencies["temporalio"] = "0.20.2"
+		pjson.Dependencies["temporalio"] = "0.23.0"
 	}
 
 	// Allow users to override any shim dependencies. Given shim code is bundled


### PR DESCRIPTION
## Description
This change updates our durable node shim to set an authentication token and use TLS when communicating with the Temporal API. The token parts rely on a just-released update to the Temporal Node SDK, so we also need to bump the version of the latter.

## Test plan
Testing completed successfully building an image locally and running it along with the changes in https://github.com/airplanedev/airport/pull/2326.