### PR TITLE
Parse schedules from yaml/json task defns

### DIFF
--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -350,3 +350,10 @@ type GetAppRequest struct {
 	ID   string
 	Slug string
 }
+
+type Schedule struct {
+	Name        string                 `json:"name"`
+	Description string                 `json:"description"`
+	CronExpr    string                 `json:"cronExpr"`
+	ParamValues map[string]interface{} `json:"paramValues"`
+}

--- a/pkg/deploy/discover/discover.go
+++ b/pkg/deploy/discover/discover.go
@@ -26,21 +26,12 @@ const (
 	ConfigSourceDefn   ConfigSource = "defn"
 )
 
-type ScheduleConfig struct {
-	Name        string
-	Description string
-	Slug        string
-	CronExpr    string
-	Params      map[string]interface{}
-}
-
 type TaskConfig struct {
 	TaskID         string
 	TaskRoot       string
 	TaskEntrypoint string
 	Def            definitions.DefinitionInterface
 	Source         ConfigSource
-	Schedules      []ScheduleConfig
 }
 
 func (c TaskConfig) GetSource() ConfigSource {

--- a/pkg/deploy/discover/discover.go
+++ b/pkg/deploy/discover/discover.go
@@ -26,12 +26,21 @@ const (
 	ConfigSourceDefn   ConfigSource = "defn"
 )
 
+type ScheduleConfig struct {
+	Name        string
+	Description string
+	Slug        string
+	CronExpr    string
+	Params      map[string]interface{}
+}
+
 type TaskConfig struct {
 	TaskID         string
 	TaskRoot       string
 	TaskEntrypoint string
 	Def            definitions.DefinitionInterface
 	Source         ConfigSource
+	Schedules      []ScheduleConfig
 }
 
 func (c TaskConfig) GetSource() ConfigSource {

--- a/pkg/deploy/taskdir/definitions/def_0_3.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3.go
@@ -43,6 +43,8 @@ type Definition_0_3 struct {
 	Timeout            int               `json:"timeout,omitempty"`
 	Runtime            build.TaskRuntime `json:"runtime,omitempty"`
 
+	Schedules map[string]ScheduleDefinition_0_3 `json:"schedules,omitempty"`
+
 	buildConfig  build.BuildConfig
 	defnFilePath string
 }
@@ -832,6 +834,13 @@ func (o *OptionDefinition_0_3) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+type ScheduleDefinition_0_3 struct {
+	Name        string                 `json:"name,omitempty"`
+	Description string                 `json:"description,omitempty"`
+	CronExpr    string                 `json:"cron"`
+	ParamValues map[string]interface{} `json:"params,omitempty"`
+}
+
 //go:embed schema_0_3.json
 var schemaStr string
 
@@ -1336,6 +1345,19 @@ func (d *Definition_0_3) SetWorkdir(taskroot, workdir string) error {
 	d.SetBuildConfig("workdir", strings.TrimPrefix(workdir, taskroot))
 
 	return nil
+}
+
+func (d *Definition_0_3) GetSchedules() map[string]api.Schedule {
+	schedules := make(map[string]api.Schedule)
+	for slug, def := range d.Schedules {
+		schedules[slug] = api.Schedule{
+			Name:        def.Name,
+			Description: def.Description,
+			CronExpr:    def.CronExpr,
+			ParamValues: def.ParamValues,
+		}
+	}
+	return schedules
 }
 
 func NewDefinitionFromTask_0_3(ctx context.Context, client api.IAPIClient, t api.Task) (Definition_0_3, error) {

--- a/pkg/deploy/taskdir/definitions/def_0_3_test.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3_test.go
@@ -1170,7 +1170,7 @@ func TestDefinitionToUpdateTaskRequest_0_3(t *testing.T) {
 	}
 }
 
-func TestDefinition_0_3GetSchedules(t *testing.T) {
+func TestDefinitionGetSchedules_0_3(t *testing.T) {
 	require := require.New(t)
 
 	def := Definition_0_3{

--- a/pkg/deploy/taskdir/definitions/def_0_3_test.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3_test.go
@@ -26,6 +26,15 @@ python:
   entrypoint: hello_world.py
 timeout: 3600
 runtime: durable
+schedules:
+  every_midnight:
+    name: Every Midnight
+    cron: 0 0 * * *
+  no_name_params:
+    cron: 0 0 * * *
+    params:
+      param_one: 5.5
+      param_two: memes
 `)
 
 var fullJSON = []byte(
@@ -47,7 +56,20 @@ var fullJSON = []byte(
 		"entrypoint": "hello_world.py"
 	},
 	"timeout": 3600,
-	"runtime": "durable"
+	"runtime": "durable",
+	"schedules": {
+		"every_midnight": {
+			"name": "Every Midnight",
+			"cron": "0 0 * * *"
+		},
+		"no_name_params": {
+			"cron": "0 0 * * *",
+			"params": {
+				"param_one": 5.5,
+				"param_two": "memes"
+			}
+		}
+	}
 }`)
 
 var yamlWithDefault = []byte(
@@ -104,6 +126,19 @@ var fullDef = Definition_0_3{
 	},
 	Runtime: "durable",
 	Timeout: 3600,
+	Schedules: map[string]ScheduleDefinition_0_3{
+		"every_midnight": {
+			Name:     "Every Midnight",
+			CronExpr: "0 0 * * *",
+		},
+		"no_name_params": {
+			CronExpr: "0 0 * * *",
+			ParamValues: map[string]interface{}{
+				"param_one": 5.5,
+				"param_two": "memes",
+			},
+		},
+	},
 }
 
 var defWithDefault = Definition_0_3{
@@ -125,7 +160,7 @@ var defWithDefault = Definition_0_3{
 	Timeout: 3600,
 }
 
-func TestDefinitionSerialization_0_3(t *testing.T) {
+func TestDefinitionMarshal_0_3(t *testing.T) {
 	// marshalling tests
 	for _, test := range []struct {
 		name     string
@@ -213,8 +248,9 @@ timeout: 300
 			assert.Equal(test.expected, bytestr)
 		})
 	}
+}
 
-	// unmarshalling tests
+func TestDefinitionUnmarshal_0_3(t *testing.T) {
 	for _, test := range []struct {
 		name     string
 		format   DefFormat
@@ -1132,4 +1168,33 @@ func TestDefinitionToUpdateTaskRequest_0_3(t *testing.T) {
 			assert.Equal(test.request, req)
 		})
 	}
+}
+
+func TestDefinition_0_3GetSchedules(t *testing.T) {
+	require := require.New(t)
+
+	def := Definition_0_3{
+		Schedules: map[string]ScheduleDefinition_0_3{
+			"foo": {
+				Name:        "Foo",
+				Description: "Does foo",
+				CronExpr:    "0 0 * * *",
+				ParamValues: map[string]interface{}{
+					"param_one": 5.5,
+				},
+			},
+		},
+	}
+
+	schedules := def.GetSchedules()
+	require.Len(schedules, 1)
+	require.Contains(schedules, "foo")
+
+	scheduleDef := schedules["foo"]
+	require.Equal(scheduleDef.Name, "Foo")
+	require.Equal(scheduleDef.Description, "Does foo")
+	require.Equal(scheduleDef.CronExpr, "0 0 * * *")
+	require.Len(scheduleDef.ParamValues, 1)
+	require.Contains(scheduleDef.ParamValues, "param_one")
+	require.Equal(scheduleDef.ParamValues["param_one"], 5.5)
 }

--- a/pkg/deploy/taskdir/definitions/interface.go
+++ b/pkg/deploy/taskdir/definitions/interface.go
@@ -37,6 +37,8 @@ type DefinitionInterface interface {
 	GetUpdateTaskRequest(ctx context.Context, client api.IAPIClient) (api.UpdateTaskRequest, error)
 	SetWorkdir(taskroot, workdir string) error
 
+	GetSchedules() map[string]api.Schedule
+
 	// Entrypoint returns ErrNoEntrypoint if the task kind definition requires no entrypoint. May be
 	// empty. May be absolute or relative; if relative, it is relative to the defn file.
 	Entrypoint() (string, error)

--- a/pkg/deploy/taskdir/definitions/schema_0_3.json
+++ b/pkg/deploy/taskdir/definitions/schema_0_3.json
@@ -488,14 +488,24 @@
           "description": "(Experimental) A map of schedules that are to be deployed with this task. The key corresponds to a unique schedule across deploys.",
           "type": "object",
           "patternProperties": {
-            ".*": {
+            "^[a-z0-9_]{1,50}$": {
               "type": "object",
               "properties": {
-                "name": { "type": "string" },
-                "description": { "type": "string" },
-                "cron": { "type": "string" },
+                "name": {
+                  "type": "string",
+                  "description": "Name of the schedule"
+                },
+                "description": {
+                  "type": "string",
+                  "description": "Description of the schedule"
+                },
+                "cron": {
+                  "type": "string",
+                  "description": "The cron string in crontab format"
+                },
                 "params": {
-                  "type": "object"
+                  "type": "object",
+                  "description": "A map of param names to values to be passed to the task each run"
                 }
               },
               "additionalProperties": false,

--- a/pkg/deploy/taskdir/definitions/schema_0_3.json
+++ b/pkg/deploy/taskdir/definitions/schema_0_3.json
@@ -485,26 +485,21 @@
           "default": ""
         },
         "schedules": {
-          "description": "Mapping of slugs to schedules for the task.",
+          "description": "(Experimental) A map of schedules that are to be deployed with this task. The key corresponds to a unique schedule across deploys.",
           "type": "object",
           "patternProperties": {
             ".*": {
-              "oneOf": [
-                { "type": "string" },
-                {
-                  "type": "object",
-                  "properties": {
-                    "name": { "type": "string" },
-                    "description": { "type": "string" },
-                    "cron": { "type": "string" },
-                    "params": {
-                      "type": "object"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": ["cron"]
+              "type": "object",
+              "properties": {
+                "name": { "type": "string" },
+                "description": { "type": "string" },
+                "cron": { "type": "string" },
+                "params": {
+                  "type": "object"
                 }
-              ]
+              },
+              "additionalProperties": false,
+              "required": ["cron"]
             }
           },
           "examples": [{ 

--- a/pkg/deploy/taskdir/definitions/schema_0_3.json
+++ b/pkg/deploy/taskdir/definitions/schema_0_3.json
@@ -487,11 +487,31 @@
         "schedules": {
           "description": "Mapping of slugs to schedules for the task.",
           "type": "object",
+          "patternProperties": {
+            ".*": {
+              "oneOf": [
+                { "type": "string" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "name": { "type": "string" },
+                    "description": { "type": "string" },
+                    "cron": { "type": "string" },
+                    "params": {
+                      "type": "object"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": ["cron"]
+                }
+              ]
+            }
+          },
           "examples": [{ 
             "run_at_midnight": {
               "name": "Daily Midnight Batch",
               "description": "Runs this task daily at midnight.",
-              "cronExpr": "0 0 * * *",
+              "cron": "0 0 * * *",
               "params": {
                 "param_one": 5,
                 "param_two": "hello"

--- a/pkg/deploy/taskdir/definitions/schema_0_3.json
+++ b/pkg/deploy/taskdir/definitions/schema_0_3.json
@@ -289,6 +289,7 @@
     "allowSelfApprovals": true,
     "timeout": true,
     "runtime": true,
+    "schedules": true,
 
     "node": true,
     "python": true,
@@ -482,6 +483,21 @@
           "description": "Set the runtime used for this task.",
           "enum": ["", "durable"],
           "default": ""
+        },
+        "schedules": {
+          "description": "Mapping of slugs to schedules for the task.",
+          "type": "object",
+          "examples": [{ 
+            "run_at_midnight": {
+              "name": "Daily Midnight Batch",
+              "description": "Runs this task daily at midnight.",
+              "cronExpr": "0 0 * * *",
+              "params": {
+                "param_one": 5,
+                "param_two": "hello"
+              }
+            }
+          }]
         }
       },
       "required": ["name", "slug"]


### PR DESCRIPTION
Resolves AIR-3725

## Description
Parses schedules from task defn files and exposes them on DefinitionInterface to be used by the CLI and api when deploying.

## Test plan
def_0_3_test.go:TestDefinitionMarshal_0_3
def_0_3_test.go:TestDefinitionGetSchedules_0_3
