### PR TITLE
Add method to parse api triggers into task definition

### DIFF
--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -45,6 +45,7 @@ type Task struct {
 	Timeout                    int                `json:"timeout" yaml:"timeout"`
 	IsArchived                 bool               `json:"isArchived" yaml:"isArchived"`
 	InterpolationMode          string             `json:"interpolationMode" yaml:"-"`
+	Triggers                   []Trigger          `json:"triggers" yaml:"-"`
 }
 
 type GetTaskRequest struct {

--- a/pkg/api/triggers.go
+++ b/pkg/api/triggers.go
@@ -5,10 +5,6 @@ import (
 	"time"
 )
 
-type ListTriggersResponse struct {
-	Triggers []Trigger `json:"triggers"`
-}
-
 type Trigger struct {
 	Name        string            `json:"name"`
 	Description string            `json:"description"`

--- a/pkg/api/triggers.go
+++ b/pkg/api/triggers.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"fmt"
+	"time"
+)
+
+type ListTriggersResponse struct {
+	Triggers []Trigger `json:"triggers"`
+}
+
+type Trigger struct {
+	Name        string            `json:"name"`
+	Description string            `json:"description"`
+	Slug        *string           `json:"slug"`
+	Kind        TriggerKind       `json:"kind"`
+	KindConfig  TriggerKindConfig `json:"kindConfig"`
+	DisabledAt  *time.Time        `json:"disabledAt"`
+	ArchivedAt  *time.Time        `json:"archivedAt"`
+}
+
+type TriggerKind string
+
+const (
+	TriggerKindUnknown  TriggerKind = ""
+	TriggerKindForm     TriggerKind = "form"
+	TriggerKindSchedule TriggerKind = "schedule"
+)
+
+type TriggerKindConfig struct {
+	Form     *TriggerKindConfigForm     `json:"form,omitempty"`
+	Schedule *TriggerKindConfigSchedule `json:"schedule,omitempty"`
+}
+
+type TriggerKindConfigForm struct {
+	Parameters Parameters `json:"parameters"`
+}
+
+type TriggerKindConfigSchedule struct {
+	ParamValues map[string]interface{} `json:"paramValues"`
+	CronExpr    CronExpr               `json:"cronExpr"`
+}
+
+type CronExpr struct {
+	Minute     string `json:"minute,omitempty"`
+	Hour       string `json:"hour,omitempty"`
+	DayOfMonth string `json:"dayOfMonth,omitempty"`
+	Month      string `json:"month,omitempty"`
+	DayOfWeek  string `json:"dayOfWeek,omitempty"`
+}
+
+func (ce CronExpr) String() string {
+	return fmt.Sprintf("%s %s %s %s %s", ce.Minute, ce.Hour, ce.DayOfMonth, ce.Month, ce.DayOfWeek)
+}

--- a/pkg/deploy/taskdir/definitions/def_0_3.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3.go
@@ -1348,6 +1348,10 @@ func (d *Definition_0_3) SetWorkdir(taskroot, workdir string) error {
 }
 
 func (d *Definition_0_3) GetSchedules() map[string]api.Schedule {
+	if len(d.Schedules) == 0 {
+		return nil
+	}
+
 	schedules := make(map[string]api.Schedule)
 	for slug, def := range d.Schedules {
 		schedules[slug] = api.Schedule{

--- a/pkg/deploy/taskdir/definitions/def_0_3.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3.go
@@ -1390,22 +1390,8 @@ func NewDefinitionFromTask_0_3(ctx context.Context, client api.IAPIClient, t api
 		d.AllowSelfApprovals = &v
 	}
 
-	return d, nil
-}
-
-type NewDefinitionFromTaskAndTriggers_0_3Request struct {
-	Task     api.Task
-	Triggers []api.Trigger
-}
-
-func NewDefinitionFromTaskAndTriggers_0_3(ctx context.Context, client api.IAPIClient, req NewDefinitionFromTaskAndTriggers_0_3Request) (Definition_0_3, error) {
-	d, err := NewDefinitionFromTask_0_3(ctx, client, req.Task)
-	if err != nil {
-		return d, err
-	}
-
 	schedules := make(map[string]ScheduleDefinition_0_3)
-	for _, trigger := range req.Triggers {
+	for _, trigger := range t.Triggers {
 		if trigger.Kind != api.TriggerKindSchedule || trigger.Slug == nil {
 			// Trigger is not a schedule deployed via code
 			continue
@@ -1425,6 +1411,7 @@ func NewDefinitionFromTaskAndTriggers_0_3(ctx context.Context, client api.IAPICl
 	if len(schedules) > 0 {
 		d.Schedules = schedules
 	}
+
 	return d, nil
 }
 

--- a/pkg/deploy/taskdir/definitions/def_0_3_test.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3_test.go
@@ -294,6 +294,15 @@ func TestDefinitionUnmarshal_0_3(t *testing.T) {
 }
 
 func TestTaskToDefinition_0_3(t *testing.T) {
+	exampleCron := api.CronExpr{
+		Minute:     "0",
+		Hour:       "0",
+		DayOfMonth: "1",
+		Month:      "*",
+		DayOfWeek:  "*",
+	}
+	exampleTime := time.Date(1996, time.May, 3, 0, 0, 0, 0, time.UTC)
+
 	for _, test := range []struct {
 		name       string
 		task       api.Task
@@ -742,37 +751,6 @@ func TestTaskToDefinition_0_3(t *testing.T) {
 				},
 			},
 		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			assert := require.New(t)
-			ctx := context.Background()
-			client := &mock.MockClient{
-				Resources: test.resources,
-			}
-			d, err := NewDefinitionFromTask_0_3(ctx, client, test.task)
-			assert.NoError(err)
-			assert.Equal(test.definition, d)
-		})
-	}
-}
-
-func TestTriggersToDefinition_0_3(t *testing.T) {
-	exampleCron := api.CronExpr{
-		Minute:     "0",
-		Hour:       "0",
-		DayOfMonth: "1",
-		Month:      "*",
-		DayOfWeek:  "*",
-	}
-	exampleTime := time.Date(1996, time.May, 3, 0, 0, 0, 0, time.UTC)
-
-	for _, test := range []struct {
-		name       string
-		task       api.Task
-		triggers   []api.Trigger
-		definition Definition_0_3
-		resources  []api.Resource
-	}{
 		{
 			name: "python task",
 			task: api.Task{
@@ -792,61 +770,61 @@ func TestTriggersToDefinition_0_3(t *testing.T) {
 						Config: pointers.String("config"),
 					},
 				},
-			},
-			triggers: []api.Trigger{
-				{
-					Name:        "disabled trigger",
-					Description: "disabled trigger",
-					Slug:        pointers.String("disabled_trigger"),
-					Kind:        api.TriggerKindSchedule,
-					KindConfig: api.TriggerKindConfig{
-						Schedule: &api.TriggerKindConfigSchedule{
-							CronExpr: exampleCron,
-						},
-					},
-					DisabledAt: &exampleTime,
-				},
-				{
-					Name:        "archived trigger",
-					Description: "archived trigger",
-					Slug:        pointers.String("archived_trigger"),
-					Kind:        api.TriggerKindSchedule,
-					KindConfig: api.TriggerKindConfig{
-						Schedule: &api.TriggerKindConfigSchedule{
-							CronExpr: exampleCron,
-						},
-					},
-					ArchivedAt: &exampleTime,
-				},
-				{
-					Name:        "form trigger",
-					Description: "form trigger",
-					Kind:        api.TriggerKindForm,
-					KindConfig: api.TriggerKindConfig{
-						Form: &api.TriggerKindConfigForm{},
-					},
-				},
-				{
-					Name:        "no slug",
-					Description: "no slug",
-					Kind:        api.TriggerKindSchedule,
-					KindConfig: api.TriggerKindConfig{
-						Schedule: &api.TriggerKindConfigSchedule{
-							CronExpr: exampleCron,
-						},
-					},
-				},
-				{
-					Name:        "good schedule",
-					Description: "good schedule",
-					Slug:        pointers.String("good_schedule"),
-					Kind:        api.TriggerKindSchedule,
-					KindConfig: api.TriggerKindConfig{
-						Schedule: &api.TriggerKindConfigSchedule{
-							ParamValues: map[string]interface{}{
-								"example_param": "hello",
+				Triggers: []api.Trigger{
+					{
+						Name:        "disabled trigger",
+						Description: "disabled trigger",
+						Slug:        pointers.String("disabled_trigger"),
+						Kind:        api.TriggerKindSchedule,
+						KindConfig: api.TriggerKindConfig{
+							Schedule: &api.TriggerKindConfigSchedule{
+								CronExpr: exampleCron,
 							},
-							CronExpr: exampleCron,
+						},
+						DisabledAt: &exampleTime,
+					},
+					{
+						Name:        "archived trigger",
+						Description: "archived trigger",
+						Slug:        pointers.String("archived_trigger"),
+						Kind:        api.TriggerKindSchedule,
+						KindConfig: api.TriggerKindConfig{
+							Schedule: &api.TriggerKindConfigSchedule{
+								CronExpr: exampleCron,
+							},
+						},
+						ArchivedAt: &exampleTime,
+					},
+					{
+						Name:        "form trigger",
+						Description: "form trigger",
+						Kind:        api.TriggerKindForm,
+						KindConfig: api.TriggerKindConfig{
+							Form: &api.TriggerKindConfigForm{},
+						},
+					},
+					{
+						Name:        "no slug",
+						Description: "no slug",
+						Kind:        api.TriggerKindSchedule,
+						KindConfig: api.TriggerKindConfig{
+							Schedule: &api.TriggerKindConfigSchedule{
+								CronExpr: exampleCron,
+							},
+						},
+					},
+					{
+						Name:        "good schedule",
+						Description: "good schedule",
+						Slug:        pointers.String("good_schedule"),
+						Kind:        api.TriggerKindSchedule,
+						KindConfig: api.TriggerKindConfig{
+							Schedule: &api.TriggerKindConfigSchedule{
+								ParamValues: map[string]interface{}{
+									"example_param": "hello",
+								},
+								CronExpr: exampleCron,
+							},
 						},
 					},
 				},
@@ -885,11 +863,7 @@ func TestTriggersToDefinition_0_3(t *testing.T) {
 			client := &mock.MockClient{
 				Resources: test.resources,
 			}
-			req := NewDefinitionFromTaskAndTriggers_0_3Request{
-				Task:     test.task,
-				Triggers: test.triggers,
-			}
-			d, err := NewDefinitionFromTaskAndTriggers_0_3(ctx, client, req)
+			d, err := NewDefinitionFromTask_0_3(ctx, client, test.task)
 			assert.NoError(err)
 			assert.Equal(test.definition, d)
 		})


### PR DESCRIPTION
## Description
We want to be able to parse triggers to populate the schedules in the task definition file. This diff exports a subset of the pkg/ap/triggers from airport to lib and then uses those to parse triggers fetched from the api into the task definition file

## Test plan
Schedules parse correctly in the cli/are added to the task defn file when initializing a task from an existing slug