### PR TITLE
Remove unnecessary call to list resources

### DIFF
--- a/pkg/deploy/taskdir/definitions/def_0_3.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3.go
@@ -1263,18 +1263,6 @@ func (d Definition_0_3) addParametersToUpdateTaskRequest(ctx context.Context, re
 }
 
 func (d Definition_0_3) addKindSpecificsToUpdateTaskRequest(ctx context.Context, client api.IAPIClient, req *api.UpdateTaskRequest) error {
-	resourcesByName := map[string]api.Resource{}
-	if d.SQL != nil || d.REST != nil {
-		// Remap resources from ref -> name to ref -> id.
-		resp, err := client.ListResources(ctx)
-		if err != nil {
-			return errors.Wrap(err, "fetching resources")
-		}
-		for _, resource := range resp.Resources {
-			resourcesByName[resource.Name] = resource
-		}
-	}
-
 	kind, options, err := d.GetKindAndOptions()
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description

I noticed this when making some changes for resource encryption - we define a mapping from name -> resource, populate it with the result of `/resources/list`, but then don't do anything with this map. This removes the unnecessary API call to list resources.

## Test plan

Tested a CLI deploy of a SQL task just to be sure, but this change should be safe since we're just removing unused code.
