### PR TITLE
Include info in initial task about param usage

### DIFF
--- a/pkg/deploy/taskdir/definitions/def_0_3.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3.go
@@ -762,6 +762,7 @@ func (d Definition_0_3) GenerateCommentedFile(format DefFormat) ([]byte, error) 
 	}
 
 	taskDefinition := new(bytes.Buffer)
+	var paramsExtraInfo string
 	switch kind {
 	case build.TaskKindImage:
 		if d.Image.Entrypoint != "" || len(d.Image.EnvVars) > 0 {
@@ -774,6 +775,7 @@ func (d Definition_0_3) GenerateCommentedFile(format DefFormat) ([]byte, error) 
 		if err := tmpl.Execute(taskDefinition, d.Image); err != nil {
 			return nil, errors.Wrap(err, "executing image template")
 		}
+		paramsExtraInfo = imageParamsExtraDescription
 	case build.TaskKindNode:
 		if len(d.Node.EnvVars) > 0 {
 			return d.Marshal(format)
@@ -807,6 +809,7 @@ func (d Definition_0_3) GenerateCommentedFile(format DefFormat) ([]byte, error) 
 		if err := tmpl.Execute(taskDefinition, d.Shell); err != nil {
 			return nil, errors.Wrap(err, "executing shell template")
 		}
+		paramsExtraInfo = shellParamsExtraDescription
 	case build.TaskKindSQL:
 		if d.SQL.Resource != "" || len(d.SQL.QueryArgs) > 0 {
 			return d.Marshal(format)
@@ -842,9 +845,10 @@ func (d Definition_0_3) GenerateCommentedFile(format DefFormat) ([]byte, error) 
 	}
 	buf := new(bytes.Buffer)
 	if err := tmpl.Execute(buf, map[string]interface{}{
-		"slug":           d.Slug,
-		"name":           d.Name,
-		"taskDefinition": taskDefinition.String(),
+		"slug":                   d.Slug,
+		"name":                   d.Name,
+		"taskDefinition":         taskDefinition.String(),
+		"paramsExtraDescription": paramsExtraInfo,
 	}); err != nil {
 		return nil, errors.Wrap(err, "executing definition template")
 	}

--- a/pkg/deploy/taskdir/definitions/fixtures/docker.task.yaml
+++ b/pkg/deploy/taskdir/definitions/fixtures/docker.task.yaml
@@ -9,7 +9,8 @@ name: My Task
 # A human-readable description for your task.
 # description: "My Airplane task"
 
-# A list of inputs to your task.
+# A list of inputs to your task. Parameters can be passed into the docker command
+# as {{params.slug}}, e.g. command: /bin/my_command --id {{params.user_id}}.
 # parameters:
 # -
 #   # An identifier for the parameter, which can be used in JavaScript

--- a/pkg/deploy/taskdir/definitions/fixtures/shell.task.yaml
+++ b/pkg/deploy/taskdir/definitions/fixtures/shell.task.yaml
@@ -9,7 +9,8 @@ name: My Task
 # A human-readable description for your task.
 # description: "My Airplane task"
 
-# A list of inputs to your task.
+# A list of inputs to your task. Parameters are passed into your script
+# as environment variables of form PARAM_{SLUG}, e.g. PARAM_USER_EMAIL.
 # parameters:
 # -
 #   # An identifier for the parameter, which can be used in JavaScript

--- a/pkg/deploy/taskdir/definitions/yaml_templates.go
+++ b/pkg/deploy/taskdir/definitions/yaml_templates.go
@@ -11,7 +11,7 @@ name: {{.name}}
 # A human-readable description for your task.
 # description: "My Airplane task"
 
-# A list of inputs to your task.
+# A list of inputs to your task.{{.paramsExtraDescription}}
 # parameters:
 # -
 #   # An identifier for the parameter, which can be used in JavaScript
@@ -115,6 +115,8 @@ shell:
   #   ENV_VAR_FROM_VALUE:
   #     value: env_var_value
 `
+const shellParamsExtraDescription = ` Parameters are passed into your script
+# as environment variables of form PARAM_{SLUG}, e.g. PARAM_USER_EMAIL.`
 
 const imageTemplate = `
 # Configuration for a Docker task.
@@ -140,6 +142,8 @@ docker:
   #   ENV_VAR_FROM_VALUE:
   #     value: env_var_value
 `
+const imageParamsExtraDescription = ` Parameters can be passed into the docker command
+# as {{params.slug}}, e.g. command: /bin/my_command --id {{params.user_id}}.`
 
 const sqlTemplate = `
 # Configuration for a SQL task.


### PR DESCRIPTION
## Description
We include this information in our docs and when configuring params in the UI, but it is also nice to include it in the initial tasks as code for those not using the UI

## Test plan
Integration tests that test the output yaml file.

FIXES AIR-3899