### PR TITLE
Make custom Temporal activities optional

### DIFF
--- a/pkg/build/workflow/worker-and-activity-shim.js
+++ b/pkg/build/workflow/worker-and-activity-shim.js
@@ -1,17 +1,14 @@
 import { NativeConnection, Worker } from '@temporalio/worker';
 
 // Activity code runs in the same node process as the worker, so we import it here directly.
-//
-// TODO: Make this path configurable.
-
-import * as customActivities from "../activities"
 import { registerActivities } from "airplane"
+// TODO: Make this path configurable.
+import * as customActivities from "../activities"
 
 // Main worker entrypoint; starts a worker that will process activities
 // and workflows for a single task queue (equivalent to airplane task revision).
 async function runWorker(params) {
   // Get temporal host, queue, and namespace from the environment.
-  //
   // TODO: Also get auth token.
   const temporalHost = process.env.AP_TEMPORAL_HOST;
   if (temporalHost === undefined) {
@@ -72,8 +69,8 @@ async function runWorker(params) {
     // to the shim.
     workflowBundle: { path: '/airplane/.airplane/workflow-bundle.js' },
     activities: {
+      ...registerActivities(),
       ...customActivities,
-      ...(registerActivities()),
     },
     connection,
     namespace,

--- a/pkg/utils/fsx/fsx.go
+++ b/pkg/utils/fsx/fsx.go
@@ -25,6 +25,20 @@ func AssertExistsAll(paths ...string) error {
 	return nil
 }
 
+// FilesExist ensures that any of the paths exists or returns an error.
+func AssertExistsAny(paths ...string) error {
+	for _, p := range paths {
+		if _, err := os.Stat(p); err == nil {
+			return nil
+		} else if os.IsNotExist(err) {
+			continue
+		} else {
+			return err
+		}
+	}
+	return fmt.Errorf("could not find any files %s", paths)
+}
+
 // Find attempts to find the path of the given filename.
 //
 // The method recursively visits parent dirs until the given

--- a/pkg/utils/fsx/fsx_test.go
+++ b/pkg/utils/fsx/fsx_test.go
@@ -2,6 +2,7 @@ package fsx
 
 import (
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -74,4 +75,40 @@ func TestFindUntil(t *testing.T) {
 	v, ok = FindUntil("testdata/a/b/c", "testdata", filename)
 	assert.True(ok)
 	assert.Equal("b", getFile(filepath.Join(v, filename)))
+}
+
+func TestAssertExistsAll(t *testing.T) {
+	var assert = require.New(t)
+
+	cwd, err := os.Getwd()
+	assert.NoError(err)
+
+	err = AssertExistsAll(
+		cwd+"/testdata/a/b/a.txt",
+		cwd+"/testdata/a/b/b.txt",
+		cwd+"/testdata/a/b/c.txt",
+	)
+	assert.ErrorContains(err, "could not find file")
+
+	err = AssertExistsAll(
+		cwd+"/testdata/a/b/b.txt",
+		cwd+"/testdata/a/b/c.txt",
+	)
+	assert.NoError(err)
+}
+
+func TestAssertExistsAny(t *testing.T) {
+	var assert = require.New(t)
+
+	cwd, err := os.Getwd()
+	assert.NoError(err)
+
+	err = AssertExistsAny(
+		cwd+"/testdata/monorepo/my/task/activities.ts",
+		cwd+"/testdata/monorepo/my/task/activities.js",
+	)
+	assert.ErrorContains(err, "could not find any files")
+
+	err = AssertExistsAny(cwd + "/testdata/monorepo/my/task/task.ts")
+	assert.NoError(err)
 }


### PR DESCRIPTION
## Description

Right now, we assume that a task's custom activities exist in a file called `activities.ts` or `activities.js` at the root of their project. However, a task may not have custom activities (if it is purely using the Node SDK) - this PR makes it so that we don't encounter an import error if neither of these files exist by creating an empty `activities.js` file, similar to how we create an empty `package.json` if the task does not contain one. The activities that are registered with the worker is the union of the activities exported by the Node SDK and the task's custom activities.

cc @colinking @yolken-airplane 

Resolves AIR-3973

## Test plan

Tested locally by deploying and running a task with & without `activities.ts`.
