### PR TITLE
Pass runtime through to workflow execution in workflow shim

### DIFF
--- a/pkg/build/workflow/workflow-shim.js
+++ b/pkg/build/workflow/workflow-shim.js
@@ -1,4 +1,5 @@
 import { proxySinks } from '@temporalio/workflow';
+import { _storage } from 'airplane';
 import task from '{{.Entrypoint}}';
 
 const { logger } = proxySinks();
@@ -9,9 +10,10 @@ const { logger } = proxySinks();
 // the Airplane API.
 export async function __airplaneEntrypoint(params) {
   logger.info('airplane_status:started');
-
   try {
-    var result = await task(JSON.parse(params[0]));
+    var result = await _storage.run({runtime: "workflow"}, async () => {
+      return await task(JSON.parse(params[0]));
+    })
   } catch (err) {
     logger.info(err);
     logger.info('airplane_output_append:error ' + JSON.stringify({ error: String(err) }));


### PR DESCRIPTION
## Description

The lib changes needed for https://github.com/airplanedev/node-sdk/pull/41 - we initialize the async local store with `runtime: "workflow"` metadata, and execute the user's code in a context that can access this metadata by using `_storage.getStore()`.

## Test plan

Tested locally by deploying a task with a relative import to the Node SDK.