### PR TITLE
Override base url with API url

### DIFF
--- a/pkg/build/app.go
+++ b/pkg/build/app.go
@@ -51,8 +51,8 @@ func app(root string, buildArgs []string) (string, error) {
 
 		{{.Args}}
 
-		ENV AIRPLANE_VIEW_ID=foo
-		ENV AIRPLANE_API_HOST=bar
+		ARG AIRPLANE_VIEW_ID=foob
+		ARG AIRPLANE_API_HOST=barb
 
 		COPY package*.json yarn.* /airplane/
 		RUN {{.InstallCommand}}

--- a/pkg/build/app.go
+++ b/pkg/build/app.go
@@ -49,8 +49,7 @@ func app(root string, buildArgs []string) (string, error) {
 		FROM {{.Base}} as builder
 		WORKDIR /airplane
 
-		ARG AIRPLANE_VIEW_ID=foob
-		ARG AIRPLANE_API_HOST=barb
+		{{.Args}}
 
 		COPY package*.json yarn.* /airplane/
 		RUN {{.InstallCommand}}

--- a/pkg/build/app.go
+++ b/pkg/build/app.go
@@ -49,8 +49,6 @@ func app(root string, buildArgs []string) (string, error) {
 		FROM {{.Base}} as builder
 		WORKDIR /airplane
 
-		{{.Args}}
-
 		ARG AIRPLANE_VIEW_ID=foob
 		ARG AIRPLANE_API_HOST=barb
 

--- a/pkg/build/app.go
+++ b/pkg/build/app.go
@@ -51,6 +51,9 @@ func app(root string, buildArgs []string) (string, error) {
 
 		{{.Args}}
 
+		ENV AIRPLANE_VIEW_ID=foo
+		ENV AIRPLANE_API_HOST=bar
+
 		COPY package*.json yarn.* /airplane/
 		RUN {{.InstallCommand}}
 

--- a/pkg/build/builder.go
+++ b/pkg/build/builder.go
@@ -327,7 +327,7 @@ func BuildDockerfile(c DockerfileConfig) (string, error) {
 	case NameShell:
 		return shell(c.Root, c.Options)
 	case NameApp:
-		return app(c.Root)
+		return app(c.Root, c.BuildArgKeys)
 	default:
 		return "", errors.Errorf("build: unknown builder type %q", c.Builder)
 	}

--- a/pkg/examples/app/simple/simple.app.yaml
+++ b/pkg/examples/app/simple/simple.app.yaml
@@ -1,1 +1,3 @@
 slug: my_app
+name: my app
+entrypoint: .

--- a/pkg/examples/app/simple/vite.config.ts
+++ b/pkg/examples/app/simple/vite.config.ts
@@ -5,7 +5,7 @@ import react from "@vitejs/plugin-react";
 export default ({ command, mode }: ResolvedConfig) => {
   process.env = { ...process.env, ...loadEnv(mode, process.cwd()) };
   const host = process.env.AIRPLANE_API_HOST || "https://api.airplane.so:5000";
-  const base = command === "serve" ? "" : `${host}/i/views/getContent/`;
+  const base = command === "build" ? `${host}/i/views/getContent/` : "";
   return defineConfig({
     plugins: [react()],
     base,

--- a/pkg/examples/app/simple/vite.config.ts
+++ b/pkg/examples/app/simple/vite.config.ts
@@ -1,11 +1,17 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv, ResolvedConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [react()],
-  base: "",
-  build: {
-    assetsDir: "",
-  },
-});
+export default ({ command, mode }: ResolvedConfig) => {
+  process.env = { ...process.env, ...loadEnv(mode, process.cwd()) };
+  const host = process.env.AIRPLANE_API_HOST || "https://api.airplane.so:5000";
+  const base = command === "serve" ? "" : `${host}/i/views/getContent/`;
+  return defineConfig({
+    plugins: [react()],
+    base,
+    envPrefix: "AIRPLANE_",
+    build: {
+      assetsDir: "",
+    },
+  });
+};

--- a/pkg/examples/app/simple/vite.config.ts
+++ b/pkg/examples/app/simple/vite.config.ts
@@ -4,7 +4,7 @@ import react from "@vitejs/plugin-react";
 // https://vitejs.dev/config/
 export default ({ command, mode }: ResolvedConfig) => {
   process.env = { ...process.env, ...loadEnv(mode, process.cwd()) };
-  const host = process.env.AIRPLANE_API_HOST || "https://api.airplane.so:5000";
+  const host = process.env.AIRPLANE_API_HOST || "https://api.airplane.dev";
   const base = command === "build" ? `${host}/i/views/getContent/` : "";
   return defineConfig({
     plugins: [react()],

--- a/pkg/examples/app/simple/vite.config.ts
+++ b/pkg/examples/app/simple/vite.config.ts
@@ -4,8 +4,10 @@ import react from "@vitejs/plugin-react";
 // https://vitejs.dev/config/
 export default ({ command, mode }: ResolvedConfig) => {
   process.env = { ...process.env, ...loadEnv(mode, process.cwd()) };
+  const viewID = process.env.AIRPLANE_VIEW_ID;
   const host = process.env.AIRPLANE_API_HOST || "https://api.airplane.dev";
-  const base = command === "build" ? `${host}/i/views/getContent/` : "";
+  const base =
+    command === "build" ? `${host}/i/views/getContent/${viewID}/` : "";
   return defineConfig({
     plugins: [react()],
     base,


### PR DESCRIPTION
## Description
To support proxying view content through the API, we need to point asset fetches at the API. This requires us to
1. Pass in the API host to hit at build time as an env var
2. Pass in the view id at build time as an env var so that the API knows which view we are getting content for
3. Update the base url to use these two pieces of data to construct a URL

The changes to the sample view are... just a sample. We're going to have to take this code and bake it into the vite config at build time.

## Test plan
This all manually works e2e!
