### PR TITLE
Read env var data from airplane args

### DIFF
--- a/pkg/build/workflow/worker-and-activity-shim.js
+++ b/pkg/build/workflow/worker-and-activity-shim.js
@@ -1,7 +1,7 @@
 import { NativeConnection, Worker } from '@temporalio/worker';
 
 // Activity code runs in the same node process as the worker, so we import it here directly.
-import { registerActivities } from "airplane"
+import { _registerActivities } from "airplane"
 // TODO: Make this path configurable.
 import * as customActivities from "../activities"
 import * as shimActivities from "./workflow-shim-activities"
@@ -70,7 +70,7 @@ async function runWorker(params) {
     // to the shim.
     workflowBundle: { path: '/airplane/.airplane/workflow-bundle.js' },
     activities: {
-      ...registerActivities(),
+      ..._registerActivities(),
       ...shimActivities,
       ...customActivities,
     },

--- a/pkg/build/workflow/workflow-shim-activities.js
+++ b/pkg/build/workflow/workflow-shim-activities.js
@@ -2,13 +2,19 @@
 // We filter using envVarNames instead of doing a deep copy of the entire process.env because the majority of
 // environment variables do not need to be accessible by the user - only their custom env vars and the env vars required
 // by our SDKs should be present in the monkey patched process.env
-export async function getEnvVars(envVarNames) {
-    let filteredEnv = {}
-    for (const name of envVarNames) {
+export async function getEnvVars(taskRevisionEnvVarNames, runtimeEnv) {
+    let env = {}
+    // Add env vars that the user has configured in the task.
+    for (const name of taskRevisionEnvVarNames) {
         if (process.env.hasOwnProperty(name)) {
-            filteredEnv[name] = process.env[name]
+            env[name] = process.env[name]
         }
     }
 
-    return filteredEnv;
+    // Add airplane-internal env vars that are used by the SDK.
+    for (const [name, value] of Object.entries(runtimeEnv)) {
+        env[name] = value
+    }
+
+    return env;
 }

--- a/pkg/build/workflow/workflow-shim.js
+++ b/pkg/build/workflow/workflow-shim.js
@@ -11,18 +11,12 @@ const { getEnvVars } = proxyActivities({
 //
 // This name must match the name we use when executing the workflow in
 // the Airplane API.
-export async function __airplaneEntrypoint(params) {
+export async function __airplaneEntrypoint(params, airplaneArgs) {
   logger.info('airplane_status:started');
 
   try {
-    // TODO: Fetch env var names from workflow memo once that field has been exposed in the Temporal SDK.
-    const envVarNames = [];
-    let env = await getEnvVars(envVarNames);
-    // Add airplane-specific environment variables that are required by our SDKs.
-    // TODO: Add env id, env slug, etc.
-    env["AIRPLANE_RUNTIME"] = "workflow"
-
     // Monkey patch process.env
+    let env = await getEnvVars(airplaneArgs.TaskRevisionEnvVarNames, airplaneArgs.RuntimeEnv);
     global.process = {
       env
     }


### PR DESCRIPTION
## Description

This PR reads from the airplane args object set when the workflow is started by the API to populate the env vars that we'll monkey patch into the Temporal workflow's `process.env`. After this, the SDK should have the env vars it needs to properly execute tasks, and user-defined env vars should work.

## Test plan

Tested locally by running a workflow task with custom env vars, and also verified the airplane-internal env vars were populated into `process.env`.