### PR TITLE
Rename TaskRevisionEnvVarNames to EnvVarNames

### DIFF
--- a/pkg/build/workflow/workflow-shim-activities.js
+++ b/pkg/build/workflow/workflow-shim-activities.js
@@ -2,10 +2,10 @@
 // We filter using envVarNames instead of doing a deep copy of the entire process.env because the majority of
 // environment variables do not need to be accessible by the user - only their custom env vars and the env vars required
 // by our SDKs should be present in the monkey patched process.env
-export async function getEnvVars(taskRevisionEnvVarNames, runtimeEnv) {
+export async function getEnvVars(envVarNames, runtimeEnv) {
     let env = {}
     // Add env vars that the user has configured in the task.
-    for (const name of taskRevisionEnvVarNames) {
+    for (const name of envVarNames) {
         if (process.env.hasOwnProperty(name)) {
             env[name] = process.env[name]
         }

--- a/pkg/build/workflow/workflow-shim.js
+++ b/pkg/build/workflow/workflow-shim.js
@@ -16,7 +16,7 @@ export async function __airplaneEntrypoint(params, airplaneArgs) {
 
   try {
     // Monkey patch process.env
-    let env = await getEnvVars(airplaneArgs.TaskRevisionEnvVarNames, airplaneArgs.RuntimeEnv);
+    let env = await getEnvVars(airplaneArgs.EnvVarNames, airplaneArgs.RuntimeEnv);
     global.process = {
       env
     }


### PR DESCRIPTION
## Description

See: https://airplanedev.slack.com/archives/C038E9488F5/p1656710043454659?thread_ts=1656709429.747769&cid=C038E9488F5

API changed here: https://github.com/airplanedev/airport/pull/2698/files

## Test plan

Run workflow locally, confirm env vars are still passed through.