### PR TITLE
Fix TS type generation

### DIFF
--- a/pkg/runtime/javascript/javascript.go
+++ b/pkg/runtime/javascript/javascript.go
@@ -57,7 +57,7 @@ type Runtime struct{}
 // Generate implementation.
 func (r Runtime) Generate(t *runtime.Task) ([]byte, fs.FileMode, error) {
 	d := data{}
-	if t != nil {
+	if t != nil && t.URL != "" {
 		d.Comment = runtime.Comment(r, t.URL)
 	}
 

--- a/pkg/runtime/javascript/javascript.go
+++ b/pkg/runtime/javascript/javascript.go
@@ -55,9 +55,9 @@ type data struct {
 type Runtime struct{}
 
 // Generate implementation.
-func (r Runtime) Generate(t *runtime.Task) ([]byte, fs.FileMode, error) {
+func (r Runtime) Generate(t *runtime.Task, opts runtime.GenerateOpts) ([]byte, fs.FileMode, error) {
 	d := data{}
-	if t != nil && t.URL != "" {
+	if t != nil && t.URL != "" && opts.GenerateComment {
 		d.Comment = runtime.Comment(r, t.URL)
 	}
 

--- a/pkg/runtime/python/python.go
+++ b/pkg/runtime/python/python.go
@@ -148,9 +148,9 @@ func checkPythonInstalled(ctx context.Context, logger logger.Logger) error {
 }
 
 // Generate implementation.
-func (r Runtime) Generate(t *runtime.Task) ([]byte, fs.FileMode, error) {
+func (r Runtime) Generate(t *runtime.Task, opts runtime.GenerateOpts) ([]byte, fs.FileMode, error) {
 	d := data{}
-	if t != nil && t.URL != "" {
+	if t != nil && t.URL != "" && opts.GenerateComment {
 		d.Comment = runtime.Comment(r, t.URL)
 	}
 

--- a/pkg/runtime/python/python.go
+++ b/pkg/runtime/python/python.go
@@ -150,7 +150,7 @@ func checkPythonInstalled(ctx context.Context, logger logger.Logger) error {
 // Generate implementation.
 func (r Runtime) Generate(t *runtime.Task) ([]byte, fs.FileMode, error) {
 	d := data{}
-	if t != nil {
+	if t != nil && t.URL != "" {
 		d.Comment = runtime.Comment(r, t.URL)
 	}
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -33,13 +33,17 @@ var (
 	ErrNotImplemented = errors.New("runtime: not implemented")
 )
 
+type GenerateOpts struct {
+	GenerateComment bool
+}
+
 // Interface repersents a runtime.
 type Interface interface {
 	// Generate accepts a task and generates code to match the task.
 	//
 	// os.FileMode is used for the permissions of the generated file. Files will typically use 0644
 	// but might use 0744 for executable scripts (e.g. shell scripts).
-	Generate(task *Task) ([]byte, os.FileMode, error)
+	Generate(task *Task, opts GenerateOpts) ([]byte, os.FileMode, error)
 
 	// Workdir attempts to detect the root of the given task path.
 	//

--- a/pkg/runtime/shell/shell.go
+++ b/pkg/runtime/shell/shell.go
@@ -106,7 +106,7 @@ func (r Runtime) PrepareRun(ctx context.Context, logger logger.Logger, opts runt
 // Generate implementation.
 func (r Runtime) Generate(t *runtime.Task) ([]byte, os.FileMode, error) {
 	d := data{}
-	if t != nil {
+	if t != nil && t.URL != "" {
 		d.Comment = runtime.Comment(r, t.URL)
 	}
 

--- a/pkg/runtime/shell/shell.go
+++ b/pkg/runtime/shell/shell.go
@@ -104,9 +104,9 @@ func (r Runtime) PrepareRun(ctx context.Context, logger logger.Logger, opts runt
 }
 
 // Generate implementation.
-func (r Runtime) Generate(t *runtime.Task) ([]byte, os.FileMode, error) {
+func (r Runtime) Generate(t *runtime.Task, opts runtime.GenerateOpts) ([]byte, os.FileMode, error) {
 	d := data{}
-	if t != nil && t.URL != "" {
+	if t != nil && t.URL != "" && opts.GenerateComment {
 		d.Comment = runtime.Comment(r, t.URL)
 	}
 

--- a/pkg/runtime/shell/shell_test.go
+++ b/pkg/runtime/shell/shell_test.go
@@ -5,24 +5,50 @@ import (
 	"testing"
 
 	"github.com/airplanedev/lib/pkg/runtime"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestShellRuntime(t *testing.T) {
-	require := require.New(t)
-
-	r := Runtime{}
-	code, fileMode, err := r.Generate(&runtime.Task{
-		URL: "https://app.airplane.dev/t/shell_simple",
-	})
-	require.NoError(err)
-	require.Equal(os.FileMode(0744), fileMode)
-	require.Equal(`#!/bin/bash
+func TestGenerateShell(t *testing.T) {
+	testCases := []struct {
+		desc            string
+		generateComment bool
+		code            string
+	}{
+		{
+			desc: "generates code",
+			code: `#!/bin/bash
+# Params are in environment variables as PARAM_{SLUG}, e.g. PARAM_USER_ID
+echo "Hello World!"
+echo "Printing env for debugging purposes:"
+env
+`,
+		},
+		{
+			desc:            "generates code with comment",
+			generateComment: true,
+			code: `#!/bin/bash
 # Linked to https://app.airplane.dev/t/shell_simple [do not edit this line]
 
 # Params are in environment variables as PARAM_{SLUG}, e.g. PARAM_USER_ID
 echo "Hello World!"
 echo "Printing env for debugging purposes:"
 env
-`, string(code))
+`,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+
+			r := Runtime{}
+			code, fileMode, err := r.Generate(&runtime.Task{
+				URL: "https://app.airplane.dev/t/shell_simple",
+			}, runtime.GenerateOpts{GenerateComment: tC.generateComment})
+			require.NoError(err)
+			assert.Equal(os.FileMode(0744), fileMode)
+			assert.Equal(tC.code, string(code))
+		})
+	}
 }

--- a/pkg/runtime/sql/sql.go
+++ b/pkg/runtime/sql/sql.go
@@ -32,7 +32,7 @@ func (r Runtime) PrepareRun(ctx context.Context, logger logger.Logger, opts runt
 }
 
 // Generate implementation.
-func (r Runtime) Generate(t *runtime.Task) ([]byte, os.FileMode, error) {
+func (r Runtime) Generate(t *runtime.Task, opts runtime.GenerateOpts) ([]byte, os.FileMode, error) {
 	return code, 0644, nil
 }
 

--- a/pkg/runtime/types.go
+++ b/pkg/runtime/types.go
@@ -1,25 +1,12 @@
 package runtime
 
+import "github.com/airplanedev/lib/pkg/api"
+
 // Task represents a task.
 type Task struct {
 	URL        string
 	Parameters Parameters
 }
-
-// Type enumerates parameter types.
-type Type string
-
-// All Parameter types.
-const (
-	TypeString    Type = "string"
-	TypeBoolean   Type = "boolean"
-	TypeUpload    Type = "upload"
-	TypeInteger   Type = "integer"
-	TypeFloat     Type = "float"
-	TypeDate      Type = "date"
-	TypeDatetime  Type = "datetime"
-	TypeConfigVar Type = "configvar"
-)
 
 type Parameters []Parameter
 
@@ -27,7 +14,7 @@ type Parameters []Parameter
 type Parameter struct {
 	Name string
 	Slug string
-	Type Type
+	Type api.Type
 }
 
 // Values represent parameters values.

--- a/pkg/runtime/typescript/templates.go
+++ b/pkg/runtime/typescript/templates.go
@@ -1,0 +1,39 @@
+package typescript
+
+import "text/template"
+
+var code = template.Must(template.New("ts").Parse(`{{with .Comment -}}
+{{.}}
+
+{{end -}}
+{{.Params}}
+
+// Put the main logic of the task in this function.
+export default async function(params: Params) {
+  console.log('parameters:', params);
+
+  // You can return data to show outputs to users.
+  // Outputs documentation: https://docs.airplane.dev/tasks/outputs
+  return [
+    {element: 'hydrogen', weight: 1.008},
+    {element: 'helium', weight: 4.0026},
+  ];
+}
+`))
+
+type paramsTemplateConfig struct {
+	TaskName   string
+	TaskParams string
+}
+
+var paramsTemplate = template.Must(template.New("tsParams").Parse(`export type {{.TaskName}}Params = {
+  {{.TaskParams}}
+};
+`))
+
+var paramTypesTemplateNoParams = template.Must(template.New("tsParamsEmpty").Parse(`export type {{.TaskName}}Params = {};
+`))
+
+var fileType = `{ __airplaneType: "upload"; id: string; url: string }`
+
+var configType = `{ name: string; value: string }`

--- a/pkg/runtime/typescript/templates.go
+++ b/pkg/runtime/typescript/templates.go
@@ -7,7 +7,6 @@ var code = template.Must(template.New("ts").Parse(`{{with .Comment -}}
 
 {{end -}}
 {{.Params}}
-
 // Put the main logic of the task in this function.
 export default async function(params: Params) {
   console.log('parameters:', params);

--- a/pkg/runtime/typescript/typescript.go
+++ b/pkg/runtime/typescript/typescript.go
@@ -23,12 +23,6 @@ type data struct {
 	Params  string
 }
 
-// Param represents the parameter.
-type param struct {
-	Name string
-	Type string
-}
-
 // Runtime implementaton.
 type Runtime struct {
 	javascript.Runtime

--- a/pkg/runtime/typescript/typescript.go
+++ b/pkg/runtime/typescript/typescript.go
@@ -41,7 +41,7 @@ func (r Runtime) Generate(t *runtime.Task, opts runtime.GenerateOpts) ([]byte, f
 		if t.URL != "" && opts.GenerateComment {
 			d.Comment = runtime.Comment(r, t.URL)
 		}
-		var params map[string]api.Type
+		params := make(map[string]api.Type, len(t.Parameters))
 		for _, p := range t.Parameters {
 			params[p.Slug] = p.Type
 

--- a/pkg/runtime/typescript/typescript.go
+++ b/pkg/runtime/typescript/typescript.go
@@ -35,10 +35,10 @@ type Runtime struct {
 }
 
 // Generate implementation.
-func (r Runtime) Generate(t *runtime.Task) ([]byte, fs.FileMode, error) {
+func (r Runtime) Generate(t *runtime.Task, opts runtime.GenerateOpts) ([]byte, fs.FileMode, error) {
 	d := data{}
 	if t != nil {
-		if t.URL != "" {
+		if t.URL != "" && opts.GenerateComment {
 			d.Comment = runtime.Comment(r, t.URL)
 		}
 		var params map[string]api.Type

--- a/pkg/runtime/typescript/typescript_test.go
+++ b/pkg/runtime/typescript/typescript_test.go
@@ -132,11 +132,11 @@ func TestCreateParamsType(t *testing.T) {
 				"integer":    api.TypeInteger,
 				"date":       api.TypeDate,
 				"upload":     api.TypeUpload,
-				"config-var": api.TypeConfigVar,
+				"config_var": api.TypeConfigVar,
 			},
 			typescriptType: `export type Params = {
-  "config-var": { name: string; value: string };
   boolean: boolean;
+  config_var: { name: string; value: string };
   date: string;
   integer: number;
   string: string;


### PR DESCRIPTION
## Description
When generating a typescript task from an existing task, we generate a type for the params. We had a bug in the code where we were no longer doing this.

Moreover, the type that we would have been generating was incorrect. I fixed the typing to be correct and extracted it into a reusable function.

## Test plan
Unit test to test the logic. I also generated a new ts task from an existing one and we now get a correct param type.
