### PR TITLE
AIR-3982 Support failed workflows

### DIFF
--- a/pkg/build/workflow/workflow-shim.js
+++ b/pkg/build/workflow/workflow-shim.js
@@ -20,7 +20,8 @@ export async function __airplaneEntrypoint(params, workflowArgs) {
   } catch (err) {
     logger.info(err);
     logger.info('airplane_output_append:error ' + JSON.stringify({ error: String(err) }));
-    throw err;
+    logger.info('airplane_output_append:error {"error":"Error executing workflow"}')
+    return
   }
 
   if (result !== undefined) {


### PR DESCRIPTION
## Description
If a workflow fails (returns an error), we should log the error so the runbroker can interpret it and mark the run as failed. The previous behavior, which throws the error again, causes temporal to retry indefinitely.

## Test plan

Tested this locally with a runbroker change for both a task that has an activity and one that's only a workflow execution

![Screen Shot 2022-07-11 at 4 28 25 PM](https://user-images.githubusercontent.com/8205327/178380686-552caf18-c2bf-4290-a42a-6a398f57491a.png)

![Screen Shot 2022-07-11 at 5 27 18 PM](https://user-images.githubusercontent.com/8205327/178380811-ddc65672-05ee-42a7-a9c5-56b918feb7cd.png)

