### PR TITLE
Use correct API host when building

### DIFF
--- a/pkg/build/view.go
+++ b/pkg/build/view.go
@@ -26,6 +26,9 @@ func view(root string, options KindOptions) (string, error) {
 	if apiHost == "" {
 		return "", errors.New("expected an api host")
 	}
+	if !strings.HasPrefix(apiHost, "https://") {
+		apiHost = "https://" + apiHost
+	}
 
 	// TODO: possibly support multiple build tools.
 	base, err := getBaseNodeImage("")


### PR DESCRIPTION
## Description
Ran into this bug during the internal alpha, this fixes CORS errors when trying to run tasks in deployed views

## Test plan
Deployed a view locally that runs a task, makes sure it works

---
cc @stepzhou @leeweisberger 
