### PR TITLE
Add Inter font link

### DIFF
--- a/pkg/build/views/index.html
+++ b/pkg/build/views/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/src/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Airplane</title>
+    <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Description

The Inter font package is too large. The inter package dependency is getting removed in https://github.com/airplanedev/views/pull/86

Rather than downloading it, add a link to the hosted font

Resolves AIR-4255

## Test plan

Not sure how to build the edited lib with CLI