### PR TITLE
Allow resources to be a list

### DIFF
--- a/pkg/deploy/taskdir/definitions/def_0_3.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3.go
@@ -1508,25 +1508,8 @@ func (r *ResourceDefinition_0_3) UnmarshalJSON(b []byte) error {
 				return errors.New("aliases in resource list must be unique")
 			}
 			r.Attachments[s] = s
-		} else if m, ok := item.(map[string]interface{}); ok {
-			keys := []string{}
-			for alias := range m {
-				keys = append(keys, alias)
-			}
-			if len(keys) != 1 {
-				return errors.New("expected only one item in resource map")
-			}
-			alias := keys[0]
-			if _, exists := r.Attachments[alias]; exists {
-				return errors.New("aliases in resource list must be unique")
-			}
-			if slug, ok := m[alias].(string); ok {
-				r.Attachments[alias] = slug
-			} else {
-				return errors.New("expected string slug value in resource map")
-			}
 		} else {
-			return errors.New("expected string or map in resource list")
+			return errors.New("expected string in resource list")
 		}
 	}
 	return nil

--- a/pkg/deploy/taskdir/definitions/def_0_3.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3.go
@@ -1533,7 +1533,16 @@ func (r *ResourceDefinition_0_3) UnmarshalJSON(b []byte) error {
 }
 
 func (r ResourceDefinition_0_3) MarshalYAML() (interface{}, error) {
-	return r.Attachments, nil
+	// Return a list if we can.
+	slugs := []string{}
+	for alias, slug := range r.Attachments {
+		// If we have a single case of alias != slug, just return the map.
+		if alias != slug {
+			return r.Attachments, nil
+		}
+		slugs = append(slugs, slug)
+	}
+	return slugs, nil
 }
 
 func (r ResourceDefinition_0_3) IsZero() bool {

--- a/pkg/deploy/taskdir/definitions/def_0_3.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3.go
@@ -25,7 +25,7 @@ type Definition_0_3 struct {
 	Slug        string                    `json:"slug"`
 	Description string                    `json:"description,omitempty"`
 	Parameters  []ParameterDefinition_0_3 `json:"parameters,omitempty"`
-	Resources   map[string]string         `json:"resources,omitempty"`
+	Resources   ResourceDefinition_0_3    `json:"resources,omitempty"`
 
 	Image  *ImageDefinition_0_3  `json:"docker,omitempty"`
 	Node   *NodeDefinition_0_3   `json:"node,omitempty"`
@@ -746,7 +746,7 @@ func (d Definition_0_3) GenerateCommentedFile(format DefFormat) ([]byte, error) 
 	if format != DefFormatYAML ||
 		d.Description != "" ||
 		len(d.Parameters) > 0 ||
-		len(d.Resources) > 0 ||
+		len(d.Resources.Attachments) > 0 ||
 		len(d.Constraints) > 0 ||
 		d.RequireRequests ||
 		!d.AllowSelfApprovals.IsZero() ||
@@ -1074,7 +1074,7 @@ func (d Definition_0_3) addParametersToUpdateTaskRequest(ctx context.Context, re
 }
 
 func (d Definition_0_3) addResourcesToUpdateTaskRequest(ctx context.Context, client api.IAPIClient, req *api.UpdateTaskRequest) error {
-	if len(d.Resources) == 0 {
+	if len(d.Resources.Attachments) == 0 {
 		return nil
 	}
 
@@ -1083,7 +1083,7 @@ func (d Definition_0_3) addResourcesToUpdateTaskRequest(ctx context.Context, cli
 		return errors.Wrap(err, "fetching resources")
 	}
 
-	for alias, slug := range d.Resources {
+	for alias, slug := range d.Resources.Attachments {
 		r, ok := resourcesBySlug[slug]
 		if ok {
 			req.Resources[alias] = r.ID
@@ -1181,7 +1181,7 @@ func (d *Definition_0_3) GetConfigAttachments() ([]api.ConfigAttachment, error) 
 }
 
 func (d *Definition_0_3) GetResourceAttachments() map[string]string {
-	return d.Resources
+	return d.Resources.Attachments
 }
 
 func (d *Definition_0_3) GetSlug() string {
@@ -1395,7 +1395,7 @@ func (d *Definition_0_3) convertResourcesFromTask(ctx context.Context, client ap
 		return errors.Wrap(err, "fetching resources")
 	}
 
-	d.Resources = make(map[string]string)
+	d.Resources.Attachments = make(map[string]string)
 	for alias, id := range t.Resources {
 		// Ignore SQL/REST resources; they get routed elsewhere.
 		if (t.Kind == build.TaskKindSQL && alias == "db") ||
@@ -1404,7 +1404,7 @@ func (d *Definition_0_3) convertResourcesFromTask(ctx context.Context, client ap
 		}
 		r, ok := resourcesByID[id]
 		if ok {
-			d.Resources[alias] = r.Slug
+			d.Resources.Attachments[alias] = r.Slug
 		}
 	}
 
@@ -1483,6 +1483,61 @@ func (d *Definition_0_3) SetBuildConfig(key string, value interface{}) {
 		d.buildConfig = map[string]interface{}{}
 	}
 	d.buildConfig[key] = value
+}
+
+type ResourceDefinition_0_3 struct {
+	Attachments map[string]string
+}
+
+func (r *ResourceDefinition_0_3) UnmarshalJSON(b []byte) error {
+	// If it's just a map, dump it in the Attachments field.
+	if err := json.Unmarshal(b, &r.Attachments); err == nil {
+		return nil
+	}
+
+	// Otherwise, expect a list.
+	var list []interface{}
+	if err := json.Unmarshal(b, &list); err != nil {
+		return err
+	}
+
+	r.Attachments = make(map[string]string)
+	for _, item := range list {
+		if s, ok := item.(string); ok {
+			if _, exists := r.Attachments[s]; exists {
+				return errors.New("aliases in resource list must be unique")
+			}
+			r.Attachments[s] = s
+		} else if m, ok := item.(map[string]interface{}); ok {
+			keys := []string{}
+			for alias := range m {
+				keys = append(keys, alias)
+			}
+			if len(keys) != 1 {
+				return errors.New("expected only one item in resource map")
+			}
+			alias := keys[0]
+			if _, exists := r.Attachments[alias]; exists {
+				return errors.New("aliases in resource list must be unique")
+			}
+			if slug, ok := m[alias].(string); ok {
+				r.Attachments[alias] = slug
+			} else {
+				return errors.New("expected string slug value in resource map")
+			}
+		} else {
+			return errors.New("expected string or map in resource list")
+		}
+	}
+	return nil
+}
+
+func (r ResourceDefinition_0_3) MarshalYAML() (interface{}, error) {
+	return r.Attachments, nil
+}
+
+func (r ResourceDefinition_0_3) IsZero() bool {
+	return len(r.Attachments) == 0
 }
 
 func getResourcesBySlug(ctx context.Context, client api.IAPIClient) (map[string]api.Resource, error) {

--- a/pkg/deploy/taskdir/definitions/def_0_3_test.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3_test.go
@@ -527,9 +527,11 @@ func TestTaskToDefinition_0_3(t *testing.T) {
 				},
 			},
 			definition: Definition_0_3{
-				Name:      "REST Task",
-				Slug:      "rest_task",
-				Resources: map[string]string{},
+				Name: "REST Task",
+				Slug: "rest_task",
+				Resources: ResourceDefinition_0_3{
+					Attachments: map[string]string{},
+				},
 				REST: &RESTDefinition_0_3{
 					Resource: "httpbin",
 					Method:   "GET",
@@ -814,9 +816,11 @@ func TestTaskToDefinition_0_3(t *testing.T) {
 				},
 			},
 			definition: Definition_0_3{
-				Name:      "REST Task",
-				Slug:      "rest_task",
-				Resources: map[string]string{},
+				Name: "REST Task",
+				Slug: "rest_task",
+				Resources: ResourceDefinition_0_3{
+					Attachments: map[string]string{},
+				},
 				REST: &RESTDefinition_0_3{
 					Resource: "httpbin",
 					Method:   "GET",
@@ -973,8 +977,10 @@ func TestTaskToDefinition_0_3(t *testing.T) {
 			definition: Definition_0_3{
 				Name: "Image Task",
 				Slug: "image_task",
-				Resources: map[string]string{
-					"db": "local_db",
+				Resources: ResourceDefinition_0_3{
+					Attachments: map[string]string{
+						"db": "local_db",
+					},
 				},
 				Image: &ImageDefinition_0_3{
 					Image:      "ubuntu:latest",
@@ -1517,8 +1523,10 @@ func TestDefinitionToUpdateTaskRequest_0_3(t *testing.T) {
 			definition: Definition_0_3{
 				Name: "Image Task",
 				Slug: "image_task",
-				Resources: map[string]string{
-					"db": "local_db",
+				Resources: ResourceDefinition_0_3{
+					Attachments: map[string]string{
+						"db": "local_db",
+					},
 				},
 				Image: &ImageDefinition_0_3{
 					Image:      "ubuntu:latest",

--- a/pkg/deploy/taskdir/definitions/schema_0_3.json
+++ b/pkg/deploy/taskdir/definitions/schema_0_3.json
@@ -404,7 +404,7 @@
             {
               "type": "array",
               "items": {
-                { "type": "string", "pattern": "^[a-z0-9_]{1,50}$" }
+                "type": "string", "pattern": "^[a-z0-9_]{1,50}$"
               }
             }
           ]

--- a/pkg/deploy/taskdir/definitions/schema_0_3.json
+++ b/pkg/deploy/taskdir/definitions/schema_0_3.json
@@ -390,7 +390,7 @@
           }
         },
         "resources": {
-          "description": "[Experimental] A map of resources that can be accessed from your task. Keys are aliases, which determine how you refer to the resource in your task; values are existing resource slugs in your Airplane team. Can also be a list of resource slugs (where the alias is the slug) or a list of objects with a single alias -> slug mapping.",
+          "description": "[Experimental] A list of resources to make available to your task. Resources are identified by slug, but can be mapped to an alias to configure how the task references the resource. If using aliases, resources are expressed as a map of alias to slug.",
           "oneOf": [
             {
               "type": "object",

--- a/pkg/deploy/taskdir/definitions/schema_0_3.json
+++ b/pkg/deploy/taskdir/definitions/schema_0_3.json
@@ -390,7 +390,7 @@
           }
         },
         "resources": {
-          "description": "[Experimental] A list of resources to make available to your task. Resources are identified by slug, but can be mapped to an alias to configure how the task references the resource. If using aliases, resources are expressed as a map of alias to slug.",
+          "description": "A list of resources to make available to your task. Resources are identified by slug, but can be mapped to an alias to configure how the task references the resource. If using aliases, resources are expressed as a map of alias to slug.",
           "oneOf": [
             {
               "type": "object",
@@ -404,20 +404,7 @@
             {
               "type": "array",
               "items": {
-                "oneOf": [
-                  { "type": "string", "pattern": "^[a-z0-9_]{1,50}$" },
-                  {
-                    "type": "object",
-                    "patternProperties": {
-                      "^[a-z0-9_]{1,50}$": {
-                        "type": "string",
-                        "pattern": "^[a-z0-9_]{1,50}$"
-                      }
-                    },
-                    "minProperties": 1,
-                    "maxProperties": 1
-                  }
-                ]
+                { "type": "string", "pattern": "^[a-z0-9_]{1,50}$" }
               }
             }
           ]

--- a/pkg/deploy/taskdir/definitions/schema_0_3.json
+++ b/pkg/deploy/taskdir/definitions/schema_0_3.json
@@ -390,14 +390,37 @@
           }
         },
         "resources": {
-          "description": "[Experimental] A map of resources that can be accessed from your task. Keys determine how you refer to the resource; values are existing resource slugs in your Airplane team.",
-          "type": "object",
-          "patternProperties": {
-            "^[a-z0-9_]{1,50}$": {
-              "type": "string",
-              "pattern": "^[a-z0-9_]{1,50}$"
+          "description": "[Experimental] A map of resources that can be accessed from your task. Keys are aliases, which determine how you refer to the resource in your task; values are existing resource slugs in your Airplane team. Can also be a list of resource slugs (where the alias is the slug) or a list of objects with a single alias -> slug mapping.",
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^[a-z0-9_]{1,50}$": {
+                  "type": "string",
+                  "pattern": "^[a-z0-9_]{1,50}$"
+                }
+              }
+            },
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  { "type": "string", "pattern": "^[a-z0-9_]{1,50}$" },
+                  {
+                    "type": "object",
+                    "patternProperties": {
+                      "^[a-z0-9_]{1,50}$": {
+                        "type": "string",
+                        "pattern": "^[a-z0-9_]{1,50}$"
+                      }
+                    },
+                    "minProperties": 1,
+                    "maxProperties": 1
+                  }
+                ]
+              }
             }
-          }
+          ]
         },
         "constraints": {
           "description": "Set label constraints to restrict this task to run only on agents with matching labels.",


### PR DESCRIPTION
## Description

Resource attachments can now be specified as a list, where each element is either a resource slug (where alias = slug) or an object with a single key (where key = alias, value = slug).

```
resources:
  - httpbin
  - db: demo_db
```

When running `airplane init`, resource attachments are preferred as a mapping of alias -> slug.

```
resources:
  httpbin: httpbin
  db: demo_db
```

## Test plan

Unit tests, tested manually.