### PR TITLE
Ensure name is valid YAML

### DIFF
--- a/pkg/deploy/taskdir/definitions/def_0_3.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3.go
@@ -837,6 +837,15 @@ func (d Definition_0_3) GenerateCommentedFile(format DefFormat) ([]byte, error) 
 		return d.Marshal(format)
 	}
 
+	// Run yaml.Marshal to take care of any weird characters. Note that this won't work if there
+	// are newlines in the name.
+	nameBuf, err := yaml.Marshal(d.Name)
+	if err != nil {
+		return nil, errors.Wrap(err, "marshalling name")
+	}
+	// yaml.Marshal always appends a newline, trim it.
+	name := strings.TrimSuffix(string(nameBuf), "\n")
+
 	tmpl, err := template.New("definition").Parse(definitionTemplate)
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing definition template")
@@ -844,7 +853,7 @@ func (d Definition_0_3) GenerateCommentedFile(format DefFormat) ([]byte, error) 
 	buf := new(bytes.Buffer)
 	if err := tmpl.Execute(buf, map[string]interface{}{
 		"slug":                   d.Slug,
-		"name":                   d.Name,
+		"name":                   name,
 		"taskDefinition":         taskDefinition.String(),
 		"paramsExtraDescription": paramsExtraInfo,
 	}); err != nil {

--- a/pkg/deploy/taskdir/definitions/def_0_3.go
+++ b/pkg/deploy/taskdir/definitions/def_0_3.go
@@ -837,9 +837,8 @@ func (d Definition_0_3) GenerateCommentedFile(format DefFormat) ([]byte, error) 
 		return d.Marshal(format)
 	}
 
-	// Run yaml.Marshal to take care of any weird characters. Note that this won't work if there
-	// are newlines in the name.
-	nameBuf, err := yaml.Marshal(d.Name)
+	// Remove any newlines from the name & run yaml.Marshal to take care of any weird characters.
+	nameBuf, err := yaml.Marshal(strings.ReplaceAll(d.Name, "\n", ""))
 	if err != nil {
 		return nil, errors.Wrap(err, "marshalling name")
 	}

--- a/pkg/deploy/taskdir/definitions/fixtures/specialchars.task.yaml
+++ b/pkg/deploy/taskdir/definitions/fixtures/specialchars.task.yaml
@@ -1,0 +1,96 @@
+# Full reference: https://docs.airplane.dev/tasks/task-definition
+
+# Used by Airplane to identify your task. Do not change.
+slug: test_my_task
+
+# A human-readable name for your task.
+name: "[Test] My Task"
+
+# A human-readable description for your task.
+# description: "My Airplane task"
+
+# A list of inputs to your task.
+# parameters:
+# -
+#   # An identifier for the parameter, which can be used in JavaScript
+#   # templates (https://docs.airplane.dev/runbooks/javascript-templates).
+#   slug: name
+#   # A human-readable name for the parameter.
+#   name: Name
+#   # The type of parameter. Valid values: shorttext, longtext, sql, boolean,
+#   # upload, integer, float, date, datetime, configvar.
+#   type: shorttext
+#   # A human-readable description of the parameter.
+#   description: The user's name.
+#   # The default value of the parameter.
+#   default: Alfred Pennyworth
+#   # Set to false to indicate that this parameter. is optional. Default: true.
+#   required: false
+#   # A list of options to constrain the parameter values. For configvar types,
+#   # each option needs to be an object with a label (value to show to user) and
+#   # a config (name of the config var). For all other types, each option can be
+#   # a single value or an object with a label and a value.
+#   options:
+#   - Alfred Pennyworth
+#   - label: Batman
+#     value: Bruce Wayne
+#   # A regular expression with which to validate parameter values.
+#   regex: "^[a-zA-Z ]+$"
+
+# Configuration for a REST task.
+rest:
+  # The name of a REST resource.
+  resource: ""
+
+  # The HTTP method to use. Valid values: GET, POST, PATCH, PUT, DELETE.
+  method: POST
+
+  # The path to request. Your REST resource may specify a path prefix as part
+  # of its base URL, in which case this path is joined to it. Airplane
+  # recommends that this start with a leading slash. Supports JavaScript
+  # templates (https://docs.airplane.dev/runbooks/javascript-templates).
+  path: /
+
+  # A map of URL parameters. Supports JavaScript templates
+  # (https://docs.airplane.dev/runbooks/javascript-templates).
+  # urlParams:
+  #   page: 3
+
+  # A map of request headers. Supports JavaScript templates
+  # (https://docs.airplane.dev/runbooks/javascript-templates).
+  # headers:
+  #   X-Api-Key: api_key
+
+  # The type of body that this request should send. Valid values: json, raw,
+  # form-data, x-www-form-urlencoded.
+  bodyType: json
+
+  # The body of the request. Supports JavaScript templates
+  # (https://docs.airplane.dev/runbooks/javascript-templates).
+  body: "{}"
+
+  # A map of form values. Supports JavaScript templates
+  # (https://docs.airplane.dev/runbooks/javascript-templates).
+  # formData:
+  #   name: Alfred Pennyworth
+
+  # A list of config variables that this task can access.
+  # configs:
+  #   - API_KEY
+  #   - DB_PASSWORD
+
+# Set label constraints to restrict this task to run only on agents with
+# matching labels.
+# constraints:
+#   aws-region: us-west-2
+
+# Set to true to disable direct execution of this task. Default: false.
+# requireRequests: true
+
+# Set to false to disallow requesters from approving their own requests for
+# this task. Default: true.
+# allowSelfApprovals: false
+
+# The maximum number of seconds the task should take before being timed out.
+# Default: 3600.
+# timeout: 1800

--- a/pkg/deploy/taskdir/definitions/yaml_templates_test.go
+++ b/pkg/deploy/taskdir/definitions/yaml_templates_test.go
@@ -12,49 +12,70 @@ import (
 func TestYAMLComments(t *testing.T) {
 	fixturesPath, _ := filepath.Abs("./fixtures")
 	for _, test := range []struct {
+		descriptor string
 		name       string
+		slug       string
 		file       string
 		kind       build.TaskKind
 		entrypoint string
 	}{
 		{
-			name:       "python",
+			descriptor: "python",
+			name:       "My Task",
+			slug:       "my_task",
 			file:       fixturesPath + "/python.task.yaml",
 			kind:       build.TaskKindPython,
 			entrypoint: "my_task.py",
 		},
 		{
-			name:       "node",
+			descriptor: "node",
+			name:       "My Task",
+			slug:       "my_task",
 			file:       fixturesPath + "/node.task.yaml",
 			kind:       build.TaskKindNode,
 			entrypoint: "my_task.ts",
 		},
 		{
-			name:       "shell",
+			descriptor: "shell",
+			name:       "My Task",
+			slug:       "my_task",
 			file:       fixturesPath + "/shell.task.yaml",
 			kind:       build.TaskKindShell,
 			entrypoint: "my_task.sh",
 		},
 		{
-			name: "docker",
-			file: fixturesPath + "/docker.task.yaml",
-			kind: build.TaskKindImage,
+			descriptor: "docker",
+			name:       "My Task",
+			slug:       "my_task",
+			file:       fixturesPath + "/docker.task.yaml",
+			kind:       build.TaskKindImage,
 		},
 		{
-			name:       "sql",
+			descriptor: "sql",
+			name:       "My Task",
+			slug:       "my_task",
 			file:       fixturesPath + "/sql.task.yaml",
 			kind:       build.TaskKindSQL,
 			entrypoint: "my_task.sql",
 		},
 		{
-			name: "rest",
-			file: fixturesPath + "/rest.task.yaml",
-			kind: build.TaskKindREST,
+			descriptor: "rest",
+			name:       "My Task",
+			slug:       "my_task",
+			file:       fixturesPath + "/rest.task.yaml",
+			kind:       build.TaskKindREST,
+		},
+		{
+			descriptor: "name with special characters",
+			name:       "[Test] My Task",
+			slug:       "test_my_task",
+			file:       fixturesPath + "/specialchars.task.yaml",
+			kind:       build.TaskKindREST,
 		},
 	} {
-		t.Run(test.name, func(t *testing.T) {
+		t.Run(test.descriptor, func(t *testing.T) {
 			require := require.New(t)
-			def, err := NewDefinition_0_3("My Task", "my_task", test.kind, test.entrypoint)
+			def, err := NewDefinition_0_3(test.name, test.slug, test.kind, test.entrypoint)
 			require.NoError(err)
 
 			got, err := def.GenerateCommentedFile(DefFormatYAML)


### PR DESCRIPTION
## Description

This only really needs to be done for name, as it's one of the few freeform fields that folks get when initializing a task. (Entrypoint is the other one, but not sticking to ascii characters for entrypoints seems like asking for trouble. Willing to punt on this.)

Resolves AIR-4252.

## Test plan

Unit tests.