### PR TITLE
Clear yarn cache after installing

### DIFF
--- a/pkg/build/node.go
+++ b/pkg/build/node.go
@@ -177,7 +177,6 @@ func node(root string, options KindOptions, buildArgs []string) (string, error) 
 			// cache directory for storing packages.
 			installCommand = "yarn install --non-interactive --production --frozen-lockfile && yarn cache clean"
 		}
-
 	} else if hasPackageLock {
 		// Use npm ci if possible, since it's faster and behaves better:
 		// https://docs.npmjs.com/cli/v8/commands/npm-ci

--- a/pkg/build/node.go
+++ b/pkg/build/node.go
@@ -171,12 +171,13 @@ func node(root string, options KindOptions, buildArgs []string) (string, error) 
 			// is no real replacement for these, so we'll just install with `yarn install`.
 			installCommand = "yarn install"
 		} else {
-			installCommand = "yarn install --non-interactive --production --frozen-lockfile"
+			// Because the install command is running in the context of a docker build, the yarn cache
+			// isn't used after the packages are installed, and so we clean the cache to keep the
+			// image lean. This doesn't apply to Yarn v2 (specifically Plug'n'Play), which uses the
+			// cache directory for storing packages.
+			installCommand = "yarn install --non-interactive --production --frozen-lockfile && yarn cache clean"
 		}
-		// Because the install command is running in the context of a docker build, the yarn cache
-		// isn't used after the packages are installed, and so we clean the cache to keep the
-		// image lean.
-		installCommand += " && yarn cache clean"
+
 	} else if hasPackageLock {
 		// Use npm ci if possible, since it's faster and behaves better:
 		// https://docs.npmjs.com/cli/v8/commands/npm-ci

--- a/pkg/build/node.go
+++ b/pkg/build/node.go
@@ -173,6 +173,10 @@ func node(root string, options KindOptions, buildArgs []string) (string, error) 
 		} else {
 			installCommand = "yarn install --non-interactive --production --frozen-lockfile"
 		}
+		// Because the install command is running in the context of a docker build, the yarn cache
+		// isn't used after the packages are installed, and so we clean the cache to keep the
+		// image lean.
+		installCommand += " && yarn cache clean"
 	} else if hasPackageLock {
 		// Use npm ci if possible, since it's faster and behaves better:
 		// https://docs.npmjs.com/cli/v8/commands/npm-ci


### PR DESCRIPTION
## Description

I've noticed that when deploying some workflow tasks, the image size is very large (~1.9GB), which causes pushing to artifact registry to take a significant amount of time. Most of the size seems to come from the yarn cache:
```
root@5a2283c9cd08:/usr/local/share/.cache# du -sh yarn
1.5G	yarn
```
Unfortunately, yarn doesn't seem to have an option to not use a cache in the first place, and so the best we can do is remove it in the same RUN instruction that we install the packages in.

## Test plan

Tested by deploying a task with the cli pointing to a local version of lib, and verifying that the size of the resulting image was reduced (~1.9GB -> 450MB).