### PR TITLE
Add size data into parsed lines

### DIFF
--- a/pkg/outputs/parse.go
+++ b/pkg/outputs/parse.go
@@ -21,6 +21,7 @@ type ParsedLine struct {
 	Name     string
 	JsonPath string
 	Value    ojson.Value
+	Size     int
 }
 
 var ErrOutputLineTooLong = errors.New("output line too long")
@@ -189,6 +190,8 @@ func Parse(chunks map[string]*strings.Builder, logText string, opts ParseOptions
 			Name:    defaultOutputName,
 			Value:   ojson.Value{V: ""},
 		}
+	} else {
+		line.Size = len(outputText)
 	}
 
 	return line, err

--- a/pkg/outputs/parse_test.go
+++ b/pkg/outputs/parse_test.go
@@ -137,6 +137,7 @@ func TestParseOutput(tt *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, test.expectedName, output.Name)
 			require.Equal(t, "", output.Command)
+			require.Equal(t, len(test.log), output.Size)
 			expectedJSON := ojson.Value{V: test.expectedValue}
 			require.Equal(t, expectedJSON, output.Value)
 		})


### PR DESCRIPTION
## Description
This change updates the lib `Parse` function to include the size of each log line in its response. This will be used for imposing output size limits in the agent v2 runbroker.

cc: @zhan-airplane 

## Test plan
Testing completed successfully via unit tests.
