### PR TITLE
Add TaskID to UpdateTaskRequest type

### DIFF
--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -128,6 +128,7 @@ type UpdateTaskRequest struct {
 	Permissions                *Permissions              `json:"permissions"`
 	ExecuteRules               UpdateExecuteRulesRequest `json:"executeRules"`
 	Timeout                    int                       `json:"timeout"`
+	TaskID			   *string                   `json:"taskID"`
 	BuildID                    *string                   `json:"buildID"`
 	InterpolationMode          *string                   `json:"interpolationMode"`
 	EnvSlug                    string                    `json:"envSlug"`


### PR DESCRIPTION
## Description

This change adds TaskID to UpdateTaskRequest so the slug can be changed as in the UI.

## Test plan

I believe the UI uses /i/tasks/update whereas the api in airplanedev/cli/pkg/api/client.go uses /v0/tasks/update, so I'm actually not sure if this will work. The ultimate goal is to allow API clients to update the task slug for an existing task like the UI does. So this will need to be tested. Marking as draft until those tests are completed.

Closes #348
